### PR TITLE
KBA-43 Added a 'terraform_bucket' config option for setting an explicit Terraform bucket.

### DIFF
--- a/kubails/services/config_store.py
+++ b/kubails/services/config_store.py
@@ -193,7 +193,7 @@ class ConfigStore:
 
         self.production_namespace = config.get("__production_namespace")
 
-        self.terraform_state_bucket = "{}-terraform".format(self.project_name)
+        self.terraform_state_bucket = config.get("__terraform_bucket", "{}-terraform".format(self.project_name))
 
     def _flatten_config_recursive(self, config: Union[Dict[str, Any], List[Any]], parent_key: str) -> Dict[str, Any]:
         flattened_config = {}


### PR DESCRIPTION
Changelog:

- Users can now specify a custom bucket for their Terraform state through the `terraform_bucket` config option in `kubails.json`.

Implementation Details:

- N/A