### PR TITLE
KBA-50 Fixed that bug where sometimes GCP APIs wouldn't be enabled during `infra setup`.

### DIFF
--- a/kubails/external_services/gcloud.py
+++ b/kubails/external_services/gcloud.py
@@ -142,7 +142,7 @@ class GoogleCloud:
         logger.info("Enabling APIs...")
 
         commands = list(map(lambda api: self.base_command + ["services", "enable", api], apis_to_enable))
-        return reduce(lambda acc, command: call_command(command) and acc, commands)
+        return reduce(lambda acc, command: call_command(command) and acc, commands, True)
 
     def create_bucket(self, bucket_name: str) -> bool:
         logger.info("Creating bucket {}...".format(bucket_name))


### PR DESCRIPTION
Changelog:

- Users should now find that `kubails infra setup` properly enables all necessary GCP APIs all the time.

Implementation Details:

- N/A