### PR TITLE
KBA-45 Added a Terraform module to handle backing up logs to a storage bucket.

### DIFF
--- a/kubails/services/config_store.py
+++ b/kubails/services/config_store.py
@@ -156,6 +156,7 @@ class ConfigStore:
         self.apis_to_enable = [
             "cloudkms.googleapis.com",
             "cloudbuild.googleapis.com",
+            "cloudresourcemanager.googleapis.com",
             "compute.googleapis.com",
             "container.googleapis.com",
             "containerregistry.googleapis.com",
@@ -184,6 +185,8 @@ class ConfigStore:
         self.service_account = "{}-account".format(self.project_name)
         self.service_account_role = "roles/editor"
         self.repo_admin_role = "roles/source.admin"
+        self.logs_configuration_writer_role = "roles/logging.configWriter"
+        self.project_iam_admin_role = "roles/resourcemanager.projectIamAdmin"
 
         self.services = config.get("__services", {})  # type: Dict[str, Dict[str, Any]]
         self.services_with_code = self._parse_services_with_code(self.services)

--- a/kubails/services/infra.py
+++ b/kubails/services/infra.py
@@ -24,8 +24,12 @@ class Infra:
 
         # Create the service account that will be used for Terraform and whatnot
         self.gcloud.create_service_account(self.config.service_account, self.config.project_title)
+
         self.gcloud.add_role_to_service_account(self.config.service_account, self.config.service_account_role)
         self.gcloud.add_role_to_service_account(self.config.service_account, self.config.repo_admin_role)
+        self.gcloud.add_role_to_service_account(self.config.service_account, self.config.logs_configuration_writer_role)
+        self.gcloud.add_role_to_service_account(self.config.service_account, self.config.project_iam_admin_role)
+
         self.gcloud.create_key_for_service_account(self.config.service_account)
 
         # Enable the Cloud Build service account to be able to administer GKE and generate service account keys

--- a/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/main.tf
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/main.tf
@@ -79,3 +79,11 @@ module "cluster" {
     services_secondary_range_name = "${module.networking.subnetwork_secondary_range_2_name}"
     services_secondary_range_cidr = "${module.networking.subnetwork_secondary_range_2_cidr}"
 }
+
+module "logging" {
+    source = "./modules/logging"
+
+    region = "${var.__gcp_project_region}"
+    cluster_name = "${module.cluster.cluster_name}"
+    logging_base_name = "${var.__gcp_project_id}"
+}

--- a/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/logging/main.tf
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/logging/main.tf
@@ -1,0 +1,31 @@
+# Storage bucket for dumping all cluster logs into.
+resource "google_storage_bucket" "cluster_logs" {
+    name = "${var.logging_base_name}-cluster-logs"
+    location = "${var.region}"
+    storage_class = "NEARLINE"
+
+    lifecycle_rule {
+        condition {
+            age = "180"  # Days
+        }
+
+        action {
+            type = "Delete"
+        }
+    }
+}
+
+# Logging sink that dumps all cluster logs into the above storage bucket.
+resource "google_logging_project_sink" "cluster_logs_sink" {
+    name = "${var.logging_base_name}-cluster-logs-sink"
+    destination = "storage.googleapis.com/${google_storage_bucket.cluster_logs.name}"
+    filter = "resource.type=k8s_container AND resource.labels.cluster_name=${var.cluster_name}"
+
+    unique_writer_identity = true
+}
+
+# An IAM binding that enables the unique service account for the logging sink to dump to the storage bucket.
+resource "google_project_iam_binding" "log_writer" {
+    role = "roles/storage.objectCreator"
+    members = ["${google_logging_project_sink.cluster_logs_sink.writer_identity}"]
+}

--- a/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/logging/variables.tf
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/logging/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+    type = "string"
+}
+
+variable "cluster_name" {
+    type = "string"
+}
+
+variable "logging_base_name" {
+    type = "string"
+}


### PR DESCRIPTION
Changelog:

- Users can now have cluster log backups as part of their Terraform infrastucture.

Implementation Details:

- Added the 'Logging Config Writer' and 'Project IAM Admin' roles to the Terraform service account (to enable using the logging sink).
- The 'Cloud Resource Manager' API is now enabled as part of the `infra setup` process (again, to enable using the logging sink).