### PR TITLE
KBA-44 Added Terraform config for creating alerts for monitoring.

### DIFF
--- a/kubails/templates/primary/{{cookiecutter.project_name}}/kubails.json
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/kubails.json
@@ -1,5 +1,6 @@
 {
     "__domain": "{{cookiecutter.domain}}",
+    "__domain_owner_email": "{{cookiecutter.domain_owner_email}}",
     "__gcp_project_id": "{{cookiecutter.gcp_project}}",
     "__gcp_project_region": "{{cookiecutter.gcp_region}}",
     "__gcp_project_zone": "{{cookiecutter.gcp_zone}}",

--- a/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/main.tf
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/main.tf
@@ -60,7 +60,7 @@ module "cluster" {
     region = "${var.__gcp_project_region}"
     zone = "${var.__gcp_project_zone}"
 
-    cluster_base_name = "${var.__project_name}-cluster"
+    cluster_base_name = "${var.__project_name}"
     initial_node_count = "${var.cluster_initial_node_count}"
     node_machine_type = "${var.cluster_machine_type}"
     node_disk_size = "${var.cluster_disk_size}"
@@ -73,6 +73,16 @@ module "cluster" {
     cluster_secondary_range_cidr = "${module.networking.subnetwork_secondary_range_1_cidr}"
     services_secondary_range_name = "${module.networking.subnetwork_secondary_range_2_name}"
     services_secondary_range_cidr = "${module.networking.subnetwork_secondary_range_2_cidr}"
+}
+
+module "monitoring" {
+    source = "./modules/monitoring"
+
+    gcp_project = "${var.__gcp_project_id}"
+
+    domain = "${var.__domain}"
+    uptime_check_base_name = "${var.__project_name}"
+    alerts_email = "${var.__domain_owner_email}"
 }
 
 module "logging" {

--- a/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/monitoring/main.tf
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/monitoring/main.tf
@@ -1,0 +1,70 @@
+locals {
+    frontend_check = "${var.uptime_check_base_name}-frontend"
+}
+
+# Uptime check for monitoring the frontend -- i.e. the root domain.
+resource "google_monitoring_uptime_check_config" "frontend_check" {
+    display_name = "${local.frontend_check}"
+    timeout = "${var.uptime_check_timeout}"
+    period = "${var.uptime_check_period}"
+
+    http_check {
+        path = "/"
+        port = "443"
+        use_ssl = true
+        validate_ssl = true
+    }
+
+    monitored_resource {
+        type = "uptime_url"
+        
+        labels {
+            project_id = "${var.gcp_project}"
+            host = "${var.domain}"
+        }
+    }
+}
+
+# Notification channel for emails.
+resource "google_monitoring_notification_channel" "email" {
+    display_name = "Email Alerts"
+    type = "email"
+
+    labels {
+        email_address = "${var.alerts_email}"
+    }
+}
+
+# Alerting policy for the frontend check that alerts on the email
+# notification channel whenever the uptime check fails.
+resource "google_monitoring_alert_policy" "frontend_check_alerting_policy" {
+    display_name = "${var.uptime_check_base_name}-frontend-alerting-policy"
+    combiner = "OR"
+
+    conditions {
+        display_name = "Uptime Check for ${local.frontend_check}"
+
+        # Figuring out this whole configuration was done by manually by creating an Uptime Check alerting policy
+        # and then inspecting its configuration using `gcloud alpha monitoring policies list`.
+        condition_threshold {
+            filter = "resource.type=\"uptime_url\" AND metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND metric.label.check_id=\"${google_monitoring_uptime_check_config.frontend_check.uptime_check_id}\""
+
+            aggregations {
+                alignment_period = "1200s"
+                cross_series_reducer = "REDUCE_COUNT_FALSE"
+                per_series_aligner = "ALIGN_NEXT_OLDER"
+                group_by_fields = ["resource.*"]
+            }
+
+            comparison = "COMPARISON_GT"
+            duration = "${var.uptime_check_period}"
+            threshold_value = "1"
+
+            trigger {
+                count = "1"
+            }
+        }
+    }
+
+    notification_channels = ["${google_monitoring_notification_channel.email.name}"]
+}

--- a/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/monitoring/variables.tf
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/monitoring/variables.tf
@@ -1,0 +1,25 @@
+variable "gcp_project" {
+    type = "string"
+}
+
+variable "domain" {
+    type = "string"
+}
+
+variable "uptime_check_base_name" {
+    type = "string"
+}
+
+variable "uptime_check_timeout" {
+    type = "string"
+    default = "10s"
+}
+
+variable "uptime_check_period" {
+    type = "string"
+    default = "300s"
+}
+
+variable "alerts_email" {
+    type = "string"
+}

--- a/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/variables.tf
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/variables.tf
@@ -18,6 +18,10 @@ variable "__domain" {
     type = "string"
 }
 
+variable "__domain_owner_email" {
+    type = "string"
+}
+
 variable "__remote_repo_host" {
     type = "string"
 }


### PR DESCRIPTION
Changelog:

- Users now have a storage bucket dedicated for storing cluster database backups.
- Fixed a bug typo where a '-cluster' suffix was left on the `cluster_base_name` variable of the `cluster` module.

Implementation Details:

- `domain_owner_email` is now a top-level Terraform variable and `kubails.json` config value.