### PR TITLE
KBA-47 Added the 'backend-database-backup' template as a new 'service' that can be generated.

### DIFF
--- a/kubails/commands/helpers.py
+++ b/kubails/commands/helpers.py
@@ -45,17 +45,17 @@ def generate_service(
         else SERVICE_GENERATION_PROMPTS["with_index"]
     )
 
-    if not service_type:
+    if service_type is None:
         service_type = click.prompt(
             prompts["service_type"].format(service_index),
             type=click.Choice(SERVICE_TEMPLATES),
             default=SERVICE_TEMPLATES[0]
         )
 
-    if not subdomain:
+    if subdomain is None:
         subdomain = click.prompt(prompts["subdomain"].format(service_index), default="")
 
-    if not title:
+    if title is None:
         title = click.prompt(prompts["title"].format(service_index))
 
     name = click.prompt(

--- a/kubails/commands/helpers.py
+++ b/kubails/commands/helpers.py
@@ -20,17 +20,6 @@ SERVICE_GENERATION_PROMPTS = {
 }
 
 
-def build_extra_service_generation_options(service_type: str) -> Dict[str, str]:
-    extra_config_options = SERVICES_CONFIG[service_type].extra_config_options
-    config_options = {}
-
-    for option in extra_config_options:
-        option_value = click.prompt(option["prompt"])
-        config_options[option["option_name"]] = option_value
-
-    return config_options
-
-
 def generate_service(
     service_service: Service,
     # Used when generating a new project (see commands/root.py)
@@ -63,5 +52,16 @@ def generate_service(
         default=title.lower().replace(" ", "-")
     )
 
-    extra_config = build_extra_service_generation_options(service_type)
+    extra_config = _build_extra_service_generation_options(service_type)
     service_service.generate(service_type, title, name, subdomain, extra_config)
+
+
+def _build_extra_service_generation_options(service_type: str) -> Dict[str, str]:
+    extra_config_options = SERVICES_CONFIG[service_type].extra_config_options
+    config_options = {}
+
+    for option in extra_config_options:
+        option_value = click.prompt(option["prompt"])
+        config_options[option["option_name"]] = option_value
+
+    return config_options

--- a/kubails/commands/helpers.py
+++ b/kubails/commands/helpers.py
@@ -1,0 +1,67 @@
+import click
+from typing import Dict
+from kubails.services.service import Service
+from kubails.templates import SERVICES_CONFIG, SERVICE_TEMPLATES
+
+
+SERVICE_GENERATION_PROMPTS = {
+    "with_index": {
+        "service_type": "Choose a template for service {}",
+        "subdomain": "Enter a subdomain for service {}",
+        "title": "Enter a title for service {}",
+        "name": "Enter a name for service {}"
+    },
+    "without_index": {
+        "service_type": "Choose a service template",
+        "subdomain": "Enter a subdomain for the service",
+        "title": "Enter a title for the service",
+        "name": "Enter a name for the service"
+    }
+}
+
+
+def build_extra_service_generation_options(service_type: str) -> Dict[str, str]:
+    extra_config_options = SERVICES_CONFIG[service_type].extra_config_options
+    config_options = {}
+
+    for option in extra_config_options:
+        option_value = click.prompt(option["prompt"])
+        config_options[option["option_name"]] = option_value
+
+    return config_options
+
+
+def generate_service(
+    service_service: Service,
+    # Used when generating a new project (see commands/root.py)
+    service_index: int = None,
+    # Need these as optional args since they could be specified as command line args
+    service_type: str = None,
+    subdomain: str = None,
+    title: str = None
+) -> None:
+    prompts = (
+        SERVICE_GENERATION_PROMPTS["without_index"] if service_index is None
+        else SERVICE_GENERATION_PROMPTS["with_index"]
+    )
+
+    if not service_type:
+        service_type = click.prompt(
+            prompts["service_type"].format(service_index),
+            type=click.Choice(SERVICE_TEMPLATES),
+            default=SERVICE_TEMPLATES[0]
+        )
+
+    if not subdomain:
+        subdomain = click.prompt(prompts["subdomain"].format(service_index), default="")
+
+    if not title:
+        title = click.prompt(prompts["title"].format(service_index))
+
+    name = click.prompt(
+        prompts["name"].format(service_index),
+        default=title.lower().replace(" ", "-")
+    )
+
+    extra_config = build_extra_service_generation_options(service_type)
+    service_service.generate(service_type, title, name, subdomain, extra_config)

--- a/kubails/commands/root.py
+++ b/kubails/commands/root.py
@@ -2,9 +2,9 @@ import click
 import logging
 import os
 from typing import List
+from kubails.commands import helpers
 from kubails.services.service import Service
 from kubails.services.templater import Templater
-from kubails.templates import SERVICE_TEMPLATES
 from kubails.utils.command_helpers import log_command_args_factory
 
 
@@ -47,23 +47,7 @@ def _generate_new_project() -> None:
         return
 
     for i in range(number_of_services):
-        service_index = i + 1
-
-        service_type = click.prompt(
-            "Choose a template for service {}".format(service_index),
-            type=click.Choice(SERVICE_TEMPLATES),
-            default=SERVICE_TEMPLATES[0]
-        )
-
-        subdomain = click.prompt("Enter a subdomain for service {}".format(service_index), default="")
-        title = click.prompt("Enter a title for service {}".format(service_index))
-
-        name = click.prompt(
-            "Enter a name for service {}".format(service_index),
-            default=title.lower().replace(" ", "-")
-        )
-
-        service_service.generate(service_type, title, name, subdomain)
+        helpers.generate_service(service_service, service_index=i+1)
         print("")
 
 

--- a/kubails/commands/service.py
+++ b/kubails/commands/service.py
@@ -1,9 +1,10 @@
 import click
 import logging
 import sys
-from typing import Dict, Tuple
+from typing import Tuple
+from kubails.commands import helpers
 from kubails.services.service import Service
-from kubails.templates import SERVICES_CONFIG, SERVICE_TEMPLATES
+from kubails.templates import SERVICE_TEMPLATES
 from kubails.utils.command_helpers import log_command_args_factory
 
 
@@ -11,27 +12,6 @@ logger = logging.getLogger(__name__)
 log_command_args = log_command_args_factory(logger, "Service '{}' args")
 
 service_service = None
-
-
-############################################################
-# Helper Functions
-############################################################
-
-
-def build_extra_service_generation_options(service_type: str) -> Dict[str, str]:
-    extra_config_options = SERVICES_CONFIG[service_type].extra_config_options
-    config_options = {}
-
-    for option in extra_config_options:
-        option_value = click.prompt(option["prompt"])
-        config_options[option["option_name"]] = option_value
-
-    return config_options
-
-
-############################################################
-# Main Click Group
-############################################################
 
 
 @click.group()
@@ -92,19 +72,24 @@ def make(command: str) -> None:
 @service.command()
 @click.option(
     "--type", "service_type",
-    prompt="Choose a service template",
+    prompt=helpers.SERVICE_GENERATION_PROMPTS["without_index"]["service_type"],
     type=click.Choice(SERVICE_TEMPLATES),
     default=SERVICE_TEMPLATES[0]
 )
-@click.option("--subdomain", prompt="Enter a subdomain for the service", default="")
-@click.option("--title", prompt="Enter a title for the service")
+@click.option(
+    "--subdomain",
+    prompt=helpers.SERVICE_GENERATION_PROMPTS["without_index"]["subdomain"],
+    default=""
+)
+@click.option("--title", prompt=helpers.SERVICE_GENERATION_PROMPTS["without_index"]["subdomain"])
 @log_command_args
 def generate(service_type: str, subdomain: str, title: str) -> None:
-    # Since 'name' needs to modify 'title' for the default, it can't be a @click.option
-    name = click.prompt("Enter a name for the service", default=title.lower().replace(" ", "-"))
-
-    extra_config = build_extra_service_generation_options(service_type)
-    service_service.generate(service_type, title, name, subdomain, extra_config)
+    helpers.generate_service(
+        service_service,
+        service_type=service_type,
+        subdomain=subdomain,
+        title=title,
+    )
 
 
 ############################################################

--- a/kubails/commands/service.py
+++ b/kubails/commands/service.py
@@ -81,7 +81,7 @@ def make(command: str) -> None:
     prompt=helpers.SERVICE_GENERATION_PROMPTS["without_index"]["subdomain"],
     default=""
 )
-@click.option("--title", prompt=helpers.SERVICE_GENERATION_PROMPTS["without_index"]["subdomain"])
+@click.option("--title", prompt=helpers.SERVICE_GENERATION_PROMPTS["without_index"]["title"])
 @log_command_args
 def generate(service_type: str, subdomain: str, title: str) -> None:
     helpers.generate_service(

--- a/kubails/commands/service.py
+++ b/kubails/commands/service.py
@@ -1,9 +1,9 @@
 import click
 import logging
 import sys
-from typing import Tuple
+from typing import Dict, Tuple
 from kubails.services.service import Service
-from kubails.templates import SERVICE_TEMPLATES
+from kubails.templates import SERVICES_CONFIG, SERVICE_TEMPLATES
 from kubails.utils.command_helpers import log_command_args_factory
 
 
@@ -11,6 +11,27 @@ logger = logging.getLogger(__name__)
 log_command_args = log_command_args_factory(logger, "Service '{}' args")
 
 service_service = None
+
+
+############################################################
+# Helper Functions
+############################################################
+
+
+def build_extra_service_generation_options(service_type: str) -> Dict[str, str]:
+    extra_config_options = SERVICES_CONFIG[service_type].extra_config_options
+    config_options = {}
+
+    for option in extra_config_options:
+        option_value = click.prompt(option["prompt"])
+        config_options[option["option_name"]] = option_value
+
+    return config_options
+
+
+############################################################
+# Main Click Group
+############################################################
 
 
 @click.group()
@@ -79,8 +100,11 @@ def make(command: str) -> None:
 @click.option("--title", prompt="Enter a title for the service")
 @log_command_args
 def generate(service_type: str, subdomain: str, title: str) -> None:
+    # Since 'name' needs to modify 'title' for the default, it can't be a @click.option
     name = click.prompt("Enter a name for the service", default=title.lower().replace(" ", "-"))
-    service_service.generate(service_type, title, name, subdomain)
+
+    extra_config = build_extra_service_generation_options(service_type)
+    service_service.generate(service_type, title, name, subdomain, extra_config)
 
 
 ############################################################

--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -237,7 +237,9 @@ class Service:
         if generated_compose_config is not None:
             self.docker_compose.add_service_config(generated_compose_config)
 
-            logger.info("Updated {} with new service config".format(os.path.join(SERVICES_FOLDER, "docker-compose.yaml")))
+            logger.info(
+                "Updated {} with new service config".format(os.path.join(SERVICES_FOLDER, "docker-compose.yaml"))
+            )
 
     def _update_wildcard_certificate(self) -> None:
         config = self.config.get_config()

--- a/kubails/templates/__init__.py
+++ b/kubails/templates/__init__.py
@@ -1,16 +1,28 @@
 from typing import Any, Dict, Type  # noqa
 from .config_generators import (  # noqa
-    ConfigGenerator, ExpressConfigGenerator, FlaskConfigGenerator, ReactConfigGenerator
+    ConfigGenerator,
+    DatabaseBackupGenerator,
+    ExpressConfigGenerator,
+    FlaskConfigGenerator,
+    ReactConfigGenerator
 )
 
+SERVICE_BACKEND_DATABASE_BACKUP = "backend-database-backup"
 SERVICE_BACKEND_EXPRESS = "backend-express"
 SERVICE_BACKEND_FEATHERS = "backend-feathers"
 SERVICE_BACKEND_FLASK = "backend-flask"
 SERVICE_FRONTEND_REACT = "frontend-react"
 
-SERVICE_TEMPLATES = [SERVICE_BACKEND_EXPRESS, SERVICE_BACKEND_FEATHERS, SERVICE_BACKEND_FLASK, SERVICE_FRONTEND_REACT]
+SERVICE_TEMPLATES = [
+    SERVICE_BACKEND_DATABASE_BACKUP,
+    SERVICE_BACKEND_EXPRESS,
+    SERVICE_BACKEND_FEATHERS,
+    SERVICE_BACKEND_FLASK,
+    SERVICE_FRONTEND_REACT
+]
 
 SERVICES_CONFIG = {
+    SERVICE_BACKEND_DATABASE_BACKUP: DatabaseBackupGenerator,
     SERVICE_BACKEND_EXPRESS: ExpressConfigGenerator,
     SERVICE_BACKEND_FEATHERS: ExpressConfigGenerator,
     SERVICE_BACKEND_FLASK: FlaskConfigGenerator,

--- a/kubails/templates/backend-database-backup/cookiecutter.json
+++ b/kubails/templates/backend-database-backup/cookiecutter.json
@@ -1,0 +1,4 @@
+{
+    "title": "Backend Database Backup",
+    "name": "{{cookiecutter.title.lower().replace(' ', '-')}}"
+}

--- a/kubails/templates/backend-database-backup/{{cookiecutter.name}}/.dockerignore
+++ b/kubails/templates/backend-database-backup/{{cookiecutter.name}}/.dockerignore
@@ -1,0 +1,10 @@
+# Files we don't want in the container
+Dockerfile
+.dockerignore
+.gitignore
+.git
+README.md
+
+# Build artifacts we definitely don't want
+node_modules
+build

--- a/kubails/templates/backend-database-backup/{{cookiecutter.name}}/.gitignore
+++ b/kubails/templates/backend-database-backup/{{cookiecutter.name}}/.gitignore
@@ -1,0 +1,112 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+*.pyc
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+node_modules/
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Visual Studio Code
+.vscode
+
+# Custom
+
+.env
+.terraform
+*.tfstate*
+.Trash-0/

--- a/kubails/templates/backend-database-backup/{{cookiecutter.name}}/Dockerfile
+++ b/kubails/templates/backend-database-backup/{{cookiecutter.name}}/Dockerfile
@@ -1,0 +1,33 @@
+FROM postgres:11.1
+
+ENV PATH="/builder/google-cloud-sdk/bin:${PATH}"
+
+RUN apt-get -y update \
+    # Install base dependencies
+    && apt-get -y install \
+        apt-transport-https \
+        software-properties-common \
+        ca-certificates \
+        curl \
+        wget \
+        build-essential \
+        python2.7 \
+        python-dev \
+        python-setuptools \
+    # Setup Google Cloud SDK (latest)
+    && mkdir -p /builder \
+    && wget -qO- https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz | tar zxv -C /builder \
+    && CLOUDSDK_PYTHON="python2.7" /builder/google-cloud-sdk/install.sh --usage-reporting=false --bash-completion=false --disable-installation-options \
+    # Install crcmod: https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod
+    && easy_install -U pip \
+    && pip install -U crcmod \
+    # Install kubectl
+    && gcloud -q components install kubectl \
+    # Clean up
+    && apt-get -y remove gcc python-dev python-setuptools wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf ~/.config/gcloud
+
+COPY backup_database.sh .
+
+CMD ["sh", "./backup_database.sh"]

--- a/kubails/templates/backend-database-backup/{{cookiecutter.name}}/Makefile
+++ b/kubails/templates/backend-database-backup/{{cookiecutter.name}}/Makefile
@@ -1,0 +1,4 @@
+.PHONY: ci
+
+ci:
+	exit 0

--- a/kubails/templates/backend-database-backup/{{cookiecutter.name}}/README.md
+++ b/kubails/templates/backend-database-backup/{{cookiecutter.name}}/README.md
@@ -1,0 +1,9 @@
+# {{cookiecutter.title}}
+
+This 'service' is actually a cronjob that gets deployed alongside every namespace to handle doing database backups on a schedule.
+
+Since it is a Kubails servce, all of the necessary configuration can be found in the root `kubails.json` config file. 
+
+# How it Works
+
+Basically, this service has its own image built and stored in Container Registry just like any other service. The only difference is that instead of using a `deployment` template, this service uses a `cronjob` template to run on a set schedule to `pg_dump` the database of the namespace and upload the dump to the `[GCP project ID]-cluster-database-backups` storage bucket. Pretty simple.

--- a/kubails/templates/backend-database-backup/{{cookiecutter.name}}/backup_database.sh
+++ b/kubails/templates/backend-database-backup/{{cookiecutter.name}}/backup_database.sh
@@ -1,0 +1,18 @@
+set -e
+
+DUMP_FILE="$NAMESPACE-database-backup-`date +%Y-%m-%d-%H-%M-%S`.dump"
+echo "Creating dump: $DUMP_FILE"
+
+pg_dump -w --blobs > $DUMP_FILE
+
+if [ $? -ne 0 ]; then
+    rm $DUMP_FILE
+    echo "Back up not created; check db connection settings"
+    exit 1
+fi
+
+# $BACKUP_BUCKET and $NAMESPACE are provided as environment variables by the cronjob resource
+gsutil mv $DUMP_FILE "gs://$BACKUP_BUCKET/$NAMESPACE/"
+
+echo "Successfully backed up"
+exit 0

--- a/kubails/templates/config_generators.py
+++ b/kubails/templates/config_generators.py
@@ -1,13 +1,18 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 from kubails.services.config_store import ConfigStore
 
 ExtraConfigType = Dict[str, str]
+ExtraConfigOptionsType = List[ExtraConfigType]
 
-"""
-Base class from which service-dependent config generators are extended from.
-Really more of an interface than anything.
-"""
+
 class ConfigGenerator:
+    """
+    Base class from which service-dependent config generators are extended from.
+    Really more of an interface than anything.
+    """
+
+    extra_config_options = []  # type: ExtraConfigOptionsType
+
     def __init__(
         self,
         name: str,
@@ -47,7 +52,7 @@ class DatabaseBackupGenerator(ConfigGenerator):
             "option_name": "database_service",
             "prompt": "Enter the name of the database service to backup"
         }
-    ]
+        ]  # type: ExtraConfigOptionsType
 
     def __init__(self, name: str, config_store: ConfigStore, extra_config: ExtraConfigType) -> None:
         ConfigGenerator.__init__(
@@ -101,8 +106,6 @@ class DatabaseBackupGenerator(ConfigGenerator):
 
 
 class ExpressConfigGenerator(ConfigGenerator):
-    extra_config_options = []
-
     def __init__(self, name: str, config_store: ConfigStore, extra_config: ExtraConfigType) -> None:
         ConfigGenerator.__init__(
             self,
@@ -211,8 +214,6 @@ class ExpressConfigGenerator(ConfigGenerator):
 
 
 class FlaskConfigGenerator(ConfigGenerator):
-    extra_config_options = []
-
     def __init__(self, name: str, config_store: ConfigStore, extra_config: ExtraConfigType) -> None:
         ConfigGenerator.__init__(
             self,
@@ -260,8 +261,6 @@ class FlaskConfigGenerator(ConfigGenerator):
 
 
 class ReactConfigGenerator(ConfigGenerator):
-    extra_config_options = []
-
     def __init__(self, name: str, config_store: ConfigStore, extra_config: ExtraConfigType) -> None:
         ConfigGenerator.__init__(
             self,

--- a/kubails/templates/primary/{{cookiecutter.project_name}}/helm/templates/cronjob.yaml
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/helm/templates/cronjob.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.__services}}
+{{- $namespace := .Values.namespace | lower}}
+{{- $isProduction := eq $namespace .Values.__production_namespace}}
+
+{{- $serviceName := .Values.serviceName}}
+{{- $serviceMap := index .Values.__services $serviceName}}
+
+{{- $tag := not (index $serviceMap "fixed_tag") | ternary (.Values.tag | default "latest") (index $serviceMap "fixed_tag")}}
+{{- $serviceImage := index $serviceMap "image"}}
+{{- $projectImage := printf "gcr.io/%s/%s-%s:%s" .Values.__gcp_project_id .Values.__project_name $serviceImage $tag}}
+{{- $image := (index $serviceMap "image_in_project") | ternary $projectImage $serviceImage}}
+
+{{- $env := index $serviceMap "env"}}
+{{- $schedule := index $serviceMap "schedule"}}
+
+{{- $pvClaimName := printf "%s-pv-claim" $serviceName}}
+{{- $volumeName := printf "%s-volume" $serviceName}}
+{{- $volumeConfig := index $serviceMap "persistent_volume"}}
+
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+    name: {{$serviceName}}
+    namespace: {{$namespace}}
+spec:
+    schedule: {{$schedule | quote}}
+    successfulJobsHistoryLimit: 1
+    failedJobsHistoryLimit: 2
+    jobTemplate:
+        spec:
+            template:
+                spec:
+                    restartPolicy: OnFailure
+                    containers:
+                    - name: {{$serviceName}}
+                      image: {{$image}}
+                      imagePullPolicy: Always
+                      env:
+                      - name: NAMESPACE
+                        value: {{$namespace}}
+
+                      {{- range $key, $value := .Values.__services}}
+                      - name: {{$key | upper | replace "-" "_"}}_PORT
+                        value: {{$value.external_port | quote}}
+                      - name: {{$key | upper | replace "-" "_"}}_HOST
+                        {{- if $isProduction}}
+                        value: {{$value.host | quote}}
+                        {{- else}}
+                        value: {{printf "%s.%s" $namespace $value.host | quote}}
+                        {{- end}}
+                      {{- end}}
+
+                      {{- range $env}}
+                      - name: {{.name}}
+                        value: {{.value | quote}}
+                      {{- end}}
+
+                      {{- if (index $serviceMap "secrets")}}
+                      {{- range (index $serviceMap "secrets" "variables")}}
+                      - name: {{.}}
+                        valueFrom:
+                            secretKeyRef:
+                                name: {{index $serviceMap "secrets" "name"}}
+                                key: {{.}}
+                      {{- end}}
+                      {{- end}}
+
+                    {{- if $volumeConfig}}
+                    {{- $subPath := index $volumeConfig "sub_path"}}
+                    volumeMounts:
+                      - name: {{$volumeName}}
+                        mountPath: {{index $volumeConfig "mount_path"}}
+                        {{- if $subPath}}
+                        subPath: {{$subPath}}
+                        {{- end}}
+                    {{- end}}
+                  
+                {{- if $volumeConfig}}
+                volumes:
+                  - name: {{$volumeName}}
+                    persistentVolumeClaim:
+                        claimName: {{$pvClaimName}}
+                {{- end}}
+{{- end}}

--- a/kubails/templates/primary/{{cookiecutter.project_name}}/helm/templates/cronjob.yaml
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/helm/templates/cronjob.yaml
@@ -1,3 +1,4 @@
+{% raw %}
 {{- if .Values.__services}}
 {{- $namespace := .Values.namespace | lower}}
 {{- $isProduction := eq $namespace .Values.__production_namespace}}
@@ -82,3 +83,4 @@ spec:
                         claimName: {{$pvClaimName}}
                 {{- end}}
 {{- end}}
+{% endraw %}


### PR DESCRIPTION
Changelog:

- Users now have the ability to generate a 'backend-database-backup' service using `kubails service generate`. This service backs up a given Postgres database to a Cloud Storage bucket on a daily basis.

Implementation Details:

- Did some refactoring to get the functionality for generating services in-line between the new project and individual service generation commands.
- Modified the external API of per-service ConfigGenerators to accept the project config as well as extra CLI config options, to have more control/customizability over service generation.