### PR TITLE
KBA-51 Fixed branch name handling to sanitize and convert all special characters to hyphens.

### DIFF
--- a/kubails/services/cluster.py
+++ b/kubails/services/cluster.py
@@ -5,7 +5,7 @@ from dotenv import dotenv_values
 from typing import List
 from kubails.external_services import gcloud, helm, kubectl, terraform
 from kubails.services import config_store, manifest_manager
-from kubails.utils.service_helpers import call_command
+from kubails.utils.service_helpers import call_command, sanitize_name
 
 
 logger = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ class Cluster:
 
     def generate_manifests(self, services: List[str], tag: str = "", namespace: str = "") -> bool:
         result = True
-        namespace = namespace.lower()
+        namespace = sanitize_name(namespace)
 
         is_production = namespace == self.config.production_namespace
         subdomain = "" if is_production else "{}.".format(namespace)
@@ -128,7 +128,7 @@ class Cluster:
 
     def deploy_manifests(self, services: List[str], namespace: str = "") -> bool:
         result = True
-        namespace = namespace.lower()
+        namespace = sanitize_name(namespace)
 
         services_dict = {s: self.config.services[s] for s in services} if services else self.config.services
 
@@ -154,7 +154,7 @@ class Cluster:
 
     def deploy_secrets(self, services: List[str], namespace: str) -> bool:
         result = True
-        namespace = namespace.lower()
+        namespace = sanitize_name(namespace)
 
         services_dict = {
             s: self.config.services_with_secrets[s] for s in services

--- a/kubails/services/notify.py
+++ b/kubails/services/notify.py
@@ -2,6 +2,7 @@ import click
 import logging
 from kubails.external_services import slack
 from kubails.services import config_store
+from kubails.utils.service_helpers import sanitize_name
 
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ class Notify:
             raise click.Abort()
 
         domain = self.config.domain
+        namespace = sanitize_name(namespace)
 
         if namespace and namespace == self.config.production_namespace:
             fields = [

--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict, List
 from kubails.external_services import docker, docker_compose
 from kubails.services import config_store, manifest_manager, templater
 from kubails.templates import ConfigGenerator, SERVICES_CONFIG
-from kubails.utils.service_helpers import call_command
+from kubails.utils.service_helpers import call_command, sanitize_name
 
 
 logger = logging.getLogger(__name__)
@@ -61,6 +61,8 @@ class Service:
         return self._run_services_make_command(command)
 
     def build(self, services: List[str], branch_tag: str = None, commit_tag: str = None) -> bool:
+        branch_tag = sanitize_name(branch_tag)
+
         def build_function(service: str) -> bool:
             service_path = self._get_service_path(service)
             fixed_tag = self._get_fixed_tag(service)
@@ -77,6 +79,8 @@ class Service:
         return self._apply_to_services(build_function, services)
 
     def push(self, services: List[str], branch_tag: str = None, commit_tag: str = None) -> bool:
+        branch_tag = sanitize_name(branch_tag)
+
         def push_function(service: str) -> bool:
             fixed_tag = self._get_fixed_tag(service)
             base_image = self._get_base_image_name(service)
@@ -123,6 +127,8 @@ class Service:
             self._update_wildcard_certificate()
 
     def _run_services_make_command(self, command: str, services: List[str] = [], tag: str = "") -> bool:
+        tag = sanitize_name(tag)
+
         def function(service: str) -> bool:
             base_image = self._get_base_image_name(service)
 

--- a/kubails/services/test_kube_git_syncer.py
+++ b/kubails/services/test_kube_git_syncer.py
@@ -1,0 +1,19 @@
+from parameterized import parameterized
+from unittest import TestCase
+from . import kube_git_syncer
+
+
+class TestKubeGitSyncer(TestCase):
+    @parameterized.expand([
+        # One unused namespace.
+        [["a1"], ["a1", "b2"], ["b2"]],
+
+        # No unused namespaces.
+        [["a1", "b2"], ["a1", "b2"], []],
+
+        # Remote branches are sanitized to match namespace naming conventino.
+        [["test/A-1"], ["test-a-1", "thing-b-2"], ["thing-b-2"]]
+    ])
+    def test_can_get_unused_namespaces(self, remote_branches, existing_namespaces, expected):
+        result = kube_git_syncer._get_unused_namespaces(remote_branches, existing_namespaces)
+        self.assertEqual(result, expected)

--- a/kubails/utils/service_helpers.py
+++ b/kubails/utils/service_helpers.py
@@ -1,3 +1,4 @@
+import re
 import inspect
 import logging
 import os
@@ -100,6 +101,14 @@ def escape_value(value: OptionValueType) -> OptionValueType:
         return [shlex.quote(v) for v in value]
     else:
         return value
+
+
+# Since branch names are used for Docker image names, Kubernetes namespaces, domains, etc,
+# they must be sanitized to not contain any special characters.
+# As such, all non-alphanumeric should be converted to hyphens.
+def sanitize_name(branch_name: str) -> str:
+    # Regex taken from https://stackoverflow.com/a/12985459.
+    return re.sub("[^0-9a-zA-Z]+", "-", branch_name.lower())
 
 
 def get_codebase_subfolder(folder: str) -> str:

--- a/kubails/utils/test_service_helpers.py
+++ b/kubails/utils/test_service_helpers.py
@@ -1,0 +1,18 @@
+from parameterized import parameterized
+from unittest import TestCase
+from . import service_helpers
+
+
+class TestServiceHelpers(TestCase):
+    @parameterized.expand([
+        # Everything is lower cased.
+        ["ABC123", "abc123"],
+        ["ABC-123", "abc-123"],
+
+        # Special characters are replaced by hyphens.
+        ["test/ABC-123", "test-abc-123"],
+        ["t@e#s$t%a^l&l*t(h)e-t_h+i=n{g}s", "t-e-s-t-a-l-l-t-h-e-t-h-i-n-g-s"],
+    ])
+    def test_can_sanitize_name(self, name, expected):
+        result = service_helpers.sanitize_name(name)
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Changelog:

- Users can now use any special characters (notably, "/") in branch names and they'll be converted to hyphens for all use cases (Docker image tags, Kubernetes namespaces, per-branch deployed subdomains, etc).

Implementation Details:

- Had to also modify the `cleanup_namespaces` algo to use this sanitization, otherwise all branch namespaces would be marked as "unused" and deleted.