### PR TITLE
KBA-54 The non-python files are now properly included when installing Kubails.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include kubails/builder *
+recursive-include kubails/templates *


### PR DESCRIPTION
Changelog:

- Users can now install Kubails with `pip` and they will properly have all of the necessary code and configurations for templates and the builder image.

Implementation Details:

- Added a MANIFEST.in file to include the non-python files.