### PR TITLE
KBA-55 Fixed syntax errors with the Terraform configs when using Terraform 0.12.

### DIFF
--- a/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/monitoring/main.tf
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/monitoring/main.tf
@@ -18,7 +18,7 @@ resource "google_monitoring_uptime_check_config" "frontend_check" {
     monitored_resource {
         type = "uptime_url"
         
-        labels {
+        labels = {
             project_id = "${var.gcp_project}"
             host = "${var.domain}"
         }
@@ -30,7 +30,7 @@ resource "google_monitoring_notification_channel" "email" {
     display_name = "Email Alerts"
     type = "email"
 
-    labels {
+    labels = {
         email_address = "${var.alerts_email}"
     }
 }

--- a/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/networking/main.tf
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/networking/main.tf
@@ -18,12 +18,12 @@ resource "google_compute_subnetwork" "primary" {
 
     ip_cidr_range = "${var.subnetwork_primary_range}"
 
-    secondary_ip_range = {
+    secondary_ip_range {
         range_name = "${var.subnetwork_name}-secondary-1"
         ip_cidr_range = "${var.subnetwork_secondary_range_1}"
     }
 
-    secondary_ip_range = {
+    secondary_ip_range {
         range_name = "${var.subnetwork_name}-secondary-2"
         ip_cidr_range = "${var.subnetwork_secondary_range_2}"
     }


### PR DESCRIPTION
Changelog:

- Users will no longer be hit with syntax errors (from the raw Terraform configs) as a result of using Terraform 0.12 instead of 0.11.

Implementation Details:

- Had to change some syntax since Terraform 0.12 is now more strict on attributes vs blocks.