### PR TITLE
KBA-56 Fixed GKE complaining an old patch version when deploying infra.

### DIFF
--- a/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/cluster/variables.tf
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/terraform/modules/cluster/variables.tf
@@ -16,7 +16,7 @@ variable "cluster_base_name" {
 
 variable "cluster_version" {
     type = "string"
-    default = "1.15.4"
+    default = "1.15"
 }
 
 variable "initial_node_count" {


### PR DESCRIPTION
Changelog:

- Users will no longer receive an error that the GKE patch version is not supported/available when deploying with `kubails infra deploy`.

Implementation Details:

- Change the default cluster version to 1.15 from 1.15.4 (dropping the patch version so that GKE just takes whatever the latest is).