### PR TITLE
KBA-58 Updated template Node Dockerfile versions to the latest 12.16.1 LTS.

### DIFF
--- a/kubails/templates/backend-express/{{cookiecutter.name}}/Dockerfile
+++ b/kubails/templates/backend-express/{{cookiecutter.name}}/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9.4-alpine
+FROM node:12.16.1-alpine
 
 RUN mkdir -p /backend
 WORKDIR /backend

--- a/kubails/templates/backend-express/{{cookiecutter.name}}/scripts/retryable-db-migrate.sh
+++ b/kubails/templates/backend-express/{{cookiecutter.name}}/scripts/retryable-db-migrate.sh
@@ -5,7 +5,10 @@ n=0
 # Tries up to 5 times to perform the migrations
 until [ $n -ge 5 ]
 do
-    timeout -t 5 npm run db:migrate && break
+    # Note that this 'timeout' is BusyBox's latest version of 'timeout',
+    # which uses a different syntax for specifying the time.
+    # Bash uses `timeout -t 5`, BusyBox uses `timeout 5`.
+    timeout 5 npm run db:migrate && break
     ((n+=1))
     sleep 2
 done

--- a/kubails/templates/backend-feathers/{{cookiecutter.name}}/Dockerfile
+++ b/kubails/templates/backend-feathers/{{cookiecutter.name}}/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15.3-alpine
+FROM node:12.16.1-alpine
 
 RUN mkdir -p /backend
 WORKDIR /backend

--- a/kubails/templates/backend-feathers/{{cookiecutter.name}}/scripts/retryable-db-migrate.sh
+++ b/kubails/templates/backend-feathers/{{cookiecutter.name}}/scripts/retryable-db-migrate.sh
@@ -5,7 +5,10 @@ n=0
 # Tries up to 5 times to perform the migrations
 until [ $n -ge 5 ]
 do
-    timeout -t 5 npm run db:migrate && break
+    # Note that this 'timeout' is BusyBox's latest version of 'timeout',
+    # which uses a different syntax for specifying the time.
+    # Bash uses `timeout -t 5`, BusyBox uses `timeout 5`.
+    timeout 5 npm run db:migrate && break
     ((n+=1))
     sleep 2
 done

--- a/kubails/templates/frontend-react/{{cookiecutter.name}}/Dockerfile
+++ b/kubails/templates/frontend-react/{{cookiecutter.name}}/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15.3-alpine
+FROM node:12.16.1-alpine
 
 ENV NPM_CONFIG_LOGLEVEL warn
 ARG app_env


### PR DESCRIPTION
Changelog:

- Users can now make use of the latest Node 12.16.1 LTS for the template Dockerfiles.

Implementation Details:

- As a result of the latest Node LTS image having an updated version of BusyBox, the 'retryable-db-migrate' script had to be fixed to use tha latest BusyBox's syntax for 'timeout'.