### PR TITLE
KBA-59 Fixed the Cloud DNS service account secret to be specified using an absolute path.

### DIFF
--- a/kubails/services/cluster.py
+++ b/kubails/services/cluster.py
@@ -68,7 +68,10 @@ class Cluster:
         cert_manager_manifests = self.manifest_manager.static_manifest_location("cert-manager")
         self.kubectl.deploy(cert_manager_manifests, recursive=True)
 
-        service_account_file = "service-account.json=./{}.json".format(self.config.service_account)
+        service_account_file = "service-account.json={}.json".format(
+            self.config.get_project_path(self.config.service_account)
+        )
+
         self.kubectl.create_secret_from_file("clouddns-service-account", service_account_file, "cert-manager")
 
     def deploy_certificate_reflector(self) -> None:

--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -198,7 +198,7 @@ class Service:
         return images
 
     def _template_service(self, service_type: str, title: str, name: str) -> None:
-        output_dir = self.config.get_project_path("services")
+        output_dir = self.config.get_project_path(SERVICES_FOLDER)
         templater.Templater.template_service(service_type, title, name, output_dir)
 
         logger.info("Created {}".format(os.path.join(SERVICES_FOLDER, name)))


### PR DESCRIPTION
Changelog:

- Users can now properly run `kubails infra deploy` from any folder in their project.

Implementation Details:

- Fixed the CLI arg that specifies the location of the service account JSON file for the Cloud DNS service account to use an absolute path instead of a relative path.