### PR TITLE
KBA-61 Added minimally functional support for Terraform 0.12.

### DIFF
--- a/kubails/external_services/test_terraform.py
+++ b/kubails/external_services/test_terraform.py
@@ -10,13 +10,13 @@ class TestCli(TestCase):
 
     @parameterized.expand([
         # Case 1: Boolean
-        (True, "\"true\""),
+        (True, "true"),
 
         # Case 2: String
-        ("value", "\"value\""),
+        ("value", "value"),
 
         # Case 3: Number
-        (3, "\"3\""),
+        (3, "3"),
 
         # Case 4: Simple dict with string value
         ({"key": "value"}, "{key=\"value\"}"),

--- a/kubails/utils/service_helpers.py
+++ b/kubails/utils/service_helpers.py
@@ -29,7 +29,8 @@ STDERR_OPTIONS = {
 def get_command_output(
     command: List[str],
     shell: bool = False,
-    stderr_redirect: str = STDERR_SUPPRESS
+    stderr_redirect: str = STDERR_SUPPRESS,
+    **kwargs
 ) -> str:
     """
     Runs a command and cleans the result for use elsewhere.
@@ -44,7 +45,7 @@ def get_command_output(
 
     try:
         stderr_option = STDERR_OPTIONS.get(stderr_redirect, subprocess.STDOUT)
-        out = subprocess.check_output(_format_command(command, shell), stderr=stderr_option, shell=shell)
+        out = subprocess.check_output(_format_command(command, shell), stderr=stderr_option, shell=shell, **kwargs)
 
         # out is a utf-8 encoded byte string that must be converted to a literal string for use
         # rstrip() takes off the seemingly always present \n that's at the end of the result


### PR DESCRIPTION
Changelog:

- Users can now use Kubails with Terraform 0.12 (tested with 0.12.24).
- Note: Using Terraform 0.12 will result in deprecation warnings related to variable interpolation; the Terraform configs have yet to be updated to be fully 0.12 compliant in order to maintain backwards compatibility with 0.11.

Implementation Details:

- Had to switch to passing `kubails.json` values to Terraform using `TF_VAR` instead `-var` options, because of a change in Terraform 0.12 requiring all passed `-var` options to be declared variables (this restriction does not apply to `TF_VAR` env variables).
- Had to change how `kubails.json` values are stringified for Terraform, since Terraform 0.12 changed value parsing to now parse double quotes literally (but only for non-map, non-list values).
- As a result of the first implementation detail, the `get_command_output` helper now takes `kwargs`. If anything, this was just an oversight since `call_command` already accepted them.