### PR TITLE
KBA-62 Improved certain user facing log messages to be more informative and easily identified.

### DIFF
--- a/kubails/commands/cluster.py
+++ b/kubails/commands/cluster.py
@@ -31,10 +31,14 @@ def authenticate() -> None:
 
 
 @cluster.command()
-@click.confirmation_option(prompt="This will delete your project's cluster. Are you sure?")
 @log_command_args
 def destroy() -> None:
-    cluster_service.destroy()
+    message = (
+        "This will delete the cluster for project '{}'. Are you sure?"
+    ).format(cluster_service.config.project_name)
+
+    if click.confirm(message):
+        cluster_service.destroy()
 
 
 @cluster.command()

--- a/kubails/commands/infra.py
+++ b/kubails/commands/infra.py
@@ -64,13 +64,18 @@ def deploy(component: str) -> None:
 
         name_servers = infra_service.get_name_servers()
 
+        print()
         logger.info(
-            "\nYou should now point the name servers of your domain "
-            "to the following before continuing:\n\n{}\n".format(name_servers)
+            "You should now point the name servers of your domain "
+            "to the following before continuing:\n\n{}".format(name_servers)
         )
+        print()
 
         if click.confirm("Have you changed the name servers?"):
-            logger.info("\nContinuing with cluster deployment...\n")
+            print()
+            logger.info("Continuing with cluster deployment...")
+            print()
+
             cluster_service.deploy()
     elif component == "builder":
         infra_service.deploy_builder()

--- a/kubails/commands/infra.py
+++ b/kubails/commands/infra.py
@@ -77,6 +77,10 @@ def deploy(component: str) -> None:
             print()
 
             cluster_service.deploy()
+
+            print()
+            logger.info("Infrastructure deployment completed!")
+            print()
     elif component == "builder":
         infra_service.deploy_builder()
     else:
@@ -84,10 +88,15 @@ def deploy(component: str) -> None:
 
 
 @infra.command()
-@click.confirmation_option(prompt="This will delete all of the project's infrastructure. Are you sure?")
 @log_command_args
 def destroy() -> None:
-    infra_service.destroy()
+    message = (
+        "This will delete all of the infrastructure for project '{}'. Are you sure?"
+    ).format(infra_service.config.project_name)
+
+    if click.confirm(message):
+        if click.confirm("Are you really sure? You want to destroy EVERYTHING?"):
+            infra_service.destroy()
 
 
 @infra.command()

--- a/kubails/commands/root.py
+++ b/kubails/commands/root.py
@@ -39,10 +39,9 @@ def _generate_new_project() -> None:
     os.chdir(project_folder)
     service_service = Service()
 
-    print("")  # New line for output
-
+    print()
     number_of_services = click.prompt("How many services does this project need?", type=int)
-    print("")
+    print()
 
     if number_of_services <= 0:
         logger.info("Well then, no services for you. Enjoy your service-less project! Exiting.")
@@ -50,7 +49,7 @@ def _generate_new_project() -> None:
 
     for i in range(number_of_services):
         helpers.generate_service(service_service, service_index=i+1)
-        print("")
+        print()
 
 
 def _get_immediate_subdirs() -> List[str]:

--- a/kubails/commands/root.py
+++ b/kubails/commands/root.py
@@ -26,6 +26,8 @@ def new() -> None:
 def _generate_new_project() -> None:
     # Need to get a listing of the current folders to find out what the
     # project folder is called after creating it.
+    # Need to do it this way because we have no way to programmatically
+    # get the name of the created project from Cookiecutter.
     current_folders = _get_immediate_subdirs()
 
     Templater.template_primary()

--- a/kubails/external_services/gcloud.py
+++ b/kubails/external_services/gcloud.py
@@ -27,7 +27,9 @@ class GoogleCloud:
         return call_command(command)
 
     def deploy_builder_image(self) -> bool:
+        print()
         logger.info("Deploying the Kubails Builder image...")
+        print()
 
         root_folder = get_codebase_folder()
         root_kubails_folder = os.path.join(root_folder, "kubails")
@@ -55,7 +57,9 @@ class GoogleCloud:
         return result
 
     def delete_builder_image(self) -> bool:
+        print()
         logger.info("Destroying the Kubails Builder image...")
+        print()
 
         command = self.base_command + [
             "container", "images", "delete", "-q",
@@ -66,7 +70,9 @@ class GoogleCloud:
         return call_command(command)
 
     def create_service_account(self, service_account: str, project_title: str) -> bool:
+        print()
         logger.info("Creating service account {}...".format(service_account))
+        print()
 
         command = self.base_command + [
             "iam", "service-accounts",
@@ -77,14 +83,18 @@ class GoogleCloud:
         return call_command(command)
 
     def delete_service_account(self, service_account: str) -> bool:
+        print()
         logger.info("Deleting service account {}...".format(service_account))
+        print()
 
         full_service_account = self._format_full_service_account(service_account)
         command = self.base_command + ["iam", "service-accounts", "delete", "-q", full_service_account]
         return call_command(command)
 
     def create_key_for_service_account(self, service_account: str, key_folder: str = ".") -> bool:
+        print()
         logger.info("Creating key for service account {}...".format(service_account))
+        print()
 
         key_file = self._format_service_account_key(service_account, key_folder)
 
@@ -139,37 +149,55 @@ class GoogleCloud:
         return call_command(command)
 
     def enable_apis(self, apis_to_enable: List[str]) -> bool:
+        print()
         logger.info("Enabling APIs...")
+        print()
+
+        def log_and_call_api_command(acc: bool, command: List[str]) -> bool:
+            # The API to enable is the last element of the command list.
+            logger.info("Enabling {}...".format(command[-1]))
+
+            return call_command(command) and acc
 
         commands = list(map(lambda api: self.base_command + ["services", "enable", api], apis_to_enable))
-        return reduce(lambda acc, command: call_command(command) and acc, commands, True)
+        return reduce(log_and_call_api_command, commands, True)
 
     def create_bucket(self, bucket_name: str) -> bool:
+        print()
         logger.info("Creating bucket {}...".format(bucket_name))
+        print()
 
         command = ["gsutil", "mb", "gs://{}".format(bucket_name)]
         return call_command(command)
 
     def delete_bucket(self, bucket_name: str) -> bool:
+        print()
         logger.info("Deleting bucket {}...".format(bucket_name))
+        print()
 
         command = ["gsutil", "rm", "-r", "gs://{}".format(bucket_name)]
         return call_command(command)
 
     def add_role_to_service_account(self, service_account: str, role: str) -> bool:
+        print()
         logger.info("Binding service account {} to role {}...".format(service_account, role))
+        print()
 
         full_service_account = self._format_full_service_account(service_account)
         return self.add_role_to_entity("serviceAccount", full_service_account, role)
 
     def add_role_to_current_user(self, role) -> bool:
         user = self.get_current_user_email()
+        print()
         logger.info("Binding user {} to role {}...".format(user, role))
+        print()
 
         return self.add_role_to_entity("user", user, role)
 
     def delete_role_from_service_account(self, service_account: str, role: str) -> bool:
+        print()
         logger.info("Removing role binding {} on service account {}...".format(role, service_account))
+        print()
 
         full_service_account = self._format_full_service_account(service_account)
         return self.delete_role_from_entity("serviceAccount", full_service_account, role)

--- a/kubails/external_services/terraform.py
+++ b/kubails/external_services/terraform.py
@@ -19,9 +19,17 @@ class Terraform:
         self.base_command = ["terraform"]
 
     def init(self) -> bool:
+        print()
+        logger.info("Initializing Terraform...")
+        print()
+
         return self.run_command("init")
 
     def deploy(self) -> bool:
+        print()
+        logger.info("Deploying Terraform infrastructure...")
+        print()
+
         return self.run_command("apply")
 
     def destroy(self) -> bool:

--- a/kubails/services/cluster.py
+++ b/kubails/services/cluster.py
@@ -84,16 +84,20 @@ class Cluster:
         self.kubectl.deploy(core_manifest)
 
         # Wait for the webhook deployment to come online before continuing.
+        print()
         logger.info(
-            "\nWaiting for cert-manager webhook deployment to be ready before continuing. "
-            "Could take several minutes...\n"
+            "Waiting for cert-manager webhook deployment to be ready before continuing. "
+            "Could take several minutes..."
         )
+        print()
 
         while not self.kubectl.is_deployment_ready("cert-manager-webhook", namespace="cert-manager"):
             time.sleep(10)
             logger.info("Still waiting for cert-manager webhook deployment...")
 
-        logger.info("\ncert-manager webhook deployment is ready! Continuing with cluster deployment...\n")
+        print()
+        logger.info("cert-manager webhook deployment is ready! Continuing with cluster deployment...")
+        print()
 
         # Deploy the other manifests.
         for manifest in other_manifests:

--- a/kubails/services/cluster.py
+++ b/kubails/services/cluster.py
@@ -32,15 +32,30 @@ class Cluster:
 
     def authenticate(self) -> None:
         cluster_name = self.terraform.get_cluster_name()
+
+        print()
+        logger.info("Authenticating to cluster {}...".format(cluster_name))
+        print()
+
         self.gcloud.authenticate_cluster(cluster_name)
 
     def deploy(self) -> None:
+        cluster_name = self.terraform.get_cluster_name()
+
+        print()
+        logger.info("Deploying static manifests to cluster {}...".format(cluster_name))
+        print()
+
         self.authenticate()
 
         self.deploy_storage_classes()
         self.deploy_ingress_controller()
         self.deploy_cert_manager()
         self.deploy_certificate_reflector()
+
+        print()
+        logger.info("Cluster deployment complete!")
+        print()
 
     def destroy(self) -> None:
         self.destroy_ingress()

--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -42,9 +42,17 @@ class Service:
         )
 
     def start(self, services: List[str]) -> None:
+        print()
+        logger.info("Starting services locally...")
+        print()
+
         self.docker_compose.up(services)
 
     def destroy(self) -> None:
+        print()
+        logger.info("Destroying service containers, networks, and volumes...")
+        print()
+
         self.docker_compose.down()
 
     def lint(self, services: List[str], tag: str) -> bool:

--- a/kubails/utils/logger.py
+++ b/kubails/utils/logger.py
@@ -20,7 +20,7 @@ def create_logger() -> logging.Logger:
     logger = logging.getLogger("")  # Put the logger at the root so that all sub modules can access it
     logger.setLevel(logging.DEBUG)
 
-    console_formatter = logging.Formatter("%(message)s")
+    console_formatter = logging.Formatter("[KUBAILS] %(message)s")
 
     console_handler = logging.StreamHandler()
     console_handler.setLevel(logging.INFO)


### PR DESCRIPTION
Changelog:

- Users will now find more/better log messages for certain commands (notably, `kubails infra setup`, `kubails infra deploy`, and `kubails infra destroy`).


Implementation Details:

- Added a '[KUBAILS]' prefix to all console log messages to better identify our messages from other tools' messages.
- Added the name of the project to the destruction confirmation messages of `kubails infra destroy` and `kubails cluster destroy` to give an extra context check.
- Added a second confirmation to `kubails infra destroy` to try and prevent disasters.
- Improved whitespace/wording of certain other log messages.