### PR TITLE
KBA-39 Modified docker-compose to use the project name so that it doesn't just use the folder name.

### DIFF
--- a/kubails/external_services/docker_compose.py
+++ b/kubails/external_services/docker_compose.py
@@ -20,9 +20,9 @@ yaml.add_representer(type(None), yaml_represent_none)
 
 
 class DockerCompose:
-    def __init__(self, compose_folder: str) -> None:
+    def __init__(self, project_name: str, compose_folder: str) -> None:
         self.compose_file_location = os.path.join(compose_folder, COMPOSE_FILE)
-        self.base_command = ["docker-compose", "--file", self.compose_file_location]
+        self.base_command = ["docker-compose", "-p", project_name, "--file", self.compose_file_location]
 
     def up(self, services: List[str]) -> bool:
         command = self.base_command + ["up", "--build"] + services

--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -35,7 +35,11 @@ class Service:
         self.config = config_store.ConfigStore()
 
         self.docker = docker.Docker()
-        self.docker_compose = docker_compose.DockerCompose(self.config.get_project_path("services"))
+
+        self.docker_compose = docker_compose.DockerCompose(
+            self.config.project_name,
+            self.config.get_project_path("services")
+        )
 
         self.manifest_manager = manifest_manager.ManifestManager(
             manifests_folder=self.config.get_project_path("manifests")

--- a/kubails/templates/primary/{{cookiecutter.project_name}}/.env
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/.env
@@ -1,0 +1,4 @@
+# This env file is just to give docker-compose a project name when not using Kubails.
+# It (currently) has no other purpose.
+# It can (and should) be committed to the repo.
+COMPOSE_PROJECT_NAME={{cookiecutter.project_name}}


### PR DESCRIPTION
Changelog:

- Users will find that `docker-compose` now uses the project name when naming containers/networks (instead of the folder name, 'services').
- As such, users no longer have to worry about `docker-compose` conflicts between multiple Kubails projects.

Implementation Details:

- The `docker-compose` project name is grabbed from two places: a new `.env` file at the root of a Kubails project and from `kubails.json`.
- When invoking `docker-compose` through Kubails, it will use the `__project_name` value in `kubails.json`.
- When invoking `docker-compose` directly (and from the root of the project), it will use the `.env` file.
- When invoking `docker-compose` directly (and from any other folder in the project), it will fall back to the folder name, 'services'.