### PR TITLE
KBA-63 Created a dependency checker to ensure all necessary tools are installed before running service commands.

### DIFF
--- a/kubails/external_services/dependency_checker.py
+++ b/kubails/external_services/dependency_checker.py
@@ -71,9 +71,9 @@ def _get_missing_dependencies(*dependencies) -> List[str]:
     return [dep for dep in dependencies if which(dep) is None]
 
 
-def _get_method_dependencies(cls: Type[T], func: Callable, dependencies_filter) -> List[str]:
+def _get_method_dependencies(cls: Type[T], func: Callable, dependencies_whitelist) -> List[str]:
     """
-    Determines all of a given method's dependencies that fall within the dependencies_filter.
+    Determines all of a given method's dependencies that fall within the dependencies_whitelist.
 
     Directly examines the source code for the method (and that of others on the class) to
     determine the dependencies.
@@ -83,7 +83,7 @@ def _get_method_dependencies(cls: Type[T], func: Callable, dependencies_filter) 
 
     @param cls      The class that the func originates from.
     @param func     The method to determine the dependencies for.
-    @param dependencies_filter  The whitelist of valid dependencies.
+    @param dependencies_whitelist  The whitelist of valid dependencies.
     """
     source = inspect.getsource(func)
 
@@ -110,13 +110,13 @@ def _get_method_dependencies(cls: Type[T], func: Callable, dependencies_filter) 
     # But we take those risks!
     for call in private_calls:
         private_method = getattr(cls, call)
-        service_calls.extend(_get_method_dependencies(cls, private_method, dependencies_filter))
+        service_calls.extend(_get_method_dependencies(cls, private_method, dependencies_whitelist))
 
     # Remove duplicates.
     service_calls = list(set(service_calls))
 
-    # Ensure only dependencies from the dependencies_filter are kept.
-    service_calls = list(filter(lambda x: x in dependencies_filter, service_calls))
+    # Ensure only dependencies from the dependencies_whitelist are kept.
+    service_calls = list(filter(lambda x: x in dependencies_whitelist, service_calls))
 
     # Sort the dependencies for the user's benefit.
     return sorted(service_calls)

--- a/kubails/external_services/dependency_checker.py
+++ b/kubails/external_services/dependency_checker.py
@@ -1,0 +1,36 @@
+import logging
+import sys
+from functools import reduce, wraps
+from shutil import which
+from typing import Callable
+
+
+logger = logging.getLogger(__name__)
+
+
+def check_dependencies(*dependencies) -> Callable:
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            _check_dependencies(*dependencies)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def _check_dependencies(*dependencies) -> None:
+    missing_deps = []
+
+    for dep in dependencies:
+        if which(dep) is None:
+            missing_deps.append(dep)
+
+    if len(missing_deps) > 0:
+        missing_deps_string = reduce(lambda acc, dep: acc + "\n- {}".format(dep), missing_deps, "")
+
+        print()
+        logger.info("You are missing the following dependencies to run this command: \n{}".format(missing_deps_string))
+
+        sys.exit(1)

--- a/kubails/external_services/dependency_checker.py
+++ b/kubails/external_services/dependency_checker.py
@@ -9,13 +9,25 @@ from typing import Any, Callable, List, Type, TypeVar
 
 logger = logging.getLogger(__name__)
 
-# Inspiration for typing 'cls' taken from https://stackoverflow.com/a/56856290.
+# Method for typing 'cls' taken from https://stackoverflow.com/a/56856290.
 T = TypeVar("T")
 
+# These are the global app dependencies. While classes can declare their own dependencies through the decorator,
+# it's best just to use these defaults because then they only have to be updated in one place.
 APP_DEPENDENCIES = ("docker", "docker-compose", "gcloud", "git", "helm", "kubectl", "make", "terraform")
 
 
 def check_dependencies(*class_dependencies) -> Callable:
+    """
+    Applies a decorator to all the public methods of a class that verifies the method's
+    necessary dependencies are installed before running the method.
+
+    @param class_dependencies   A whitelist of dependencies that the entire class uses.
+                                Used to ensure a method's dependencies only come from this list.
+
+    @return The decorator function for a class.
+    """
+    # Since we can't set the default value of an unpacked arg list in the function definition, we set it here.
     if len(class_dependencies) == 0:
         class_dependencies = APP_DEPENDENCIES
 
@@ -35,39 +47,76 @@ def check_dependencies_for_function(*dependencies) -> Callable:
     def decorator(func: Callable) -> Callable:
         @wraps(func)
         def wrapper(*args, **kwargs) -> Any:
-            _check_dependencies(*dependencies)
-            # return func(*args, **kwargs)
+            missing_deps = _get_missing_dependencies(*dependencies)
+
+            if len(missing_deps) > 1:
+                logger.debug("Required dependencies: {}".format(dependencies))
+
+                missing_deps_string = reduce(lambda acc, dep: acc + "\n- {}".format(dep), missing_deps, "")
+                logger.info(
+                    "You are missing the following dependencies to run this command: \n{}".format(missing_deps_string)
+                )
+
+                sys.exit(1)
+            else:
+                return func(*args, **kwargs)
 
         return wrapper
 
     return decorator
 
 
-def _check_dependencies(*dependencies) -> None:
-    missing_deps = []
-
-    for dep in dependencies:
-        if which(dep) is None:
-            missing_deps.append(dep)
-
-    if len(missing_deps) > 0:
-        missing_deps_string = reduce(lambda acc, dep: acc + "\n- {}".format(dep), missing_deps, "")
-        logger.info("You are missing the following dependencies to run this command: \n{}".format(missing_deps_string))
-
-        sys.exit(1)
+def _get_missing_dependencies(*dependencies) -> List[str]:
+    # Use 'which' (like, the bash 'which') to check if the dependency is installed.
+    return [dep for dep in dependencies if which(dep) is None]
 
 
 def _get_method_dependencies(cls: Type[T], func: Callable, dependencies_filter) -> List[str]:
+    """
+    Determines all of a given method's dependencies that fall within the dependencies_filter.
+
+    Directly examines the source code for the method (and that of others on the class) to
+    determine the dependencies.
+
+    Yes, it's pretty jank that we're doing this by inspecting source code and using regex,
+    _but it works!_ (for now...)
+
+    @param cls      The class that the func originates from.
+    @param func     The method to determine the dependencies for.
+    @param dependencies_filter  The whitelist of valid dependencies.
+    """
     source = inspect.getsource(func)
 
+    # This first regex matches all public, instance methods
+    # (i.e. everything between "self." and ".").
+    # e.g. "self.terraform.get_cluster_name()" matches "terraform".
+    #
+    # The parentheses in the regex are a 'capturing group'.
+    #
+    # This only works for finding 'service' calls because all of our external_services
+    # are registered as public instance methods as part of the constructor for each service.
     service_calls = re.findall(r"self\.(\w*)\.", source)
+
+    # This second regex matches all private, instance methods
+    # (i.e. everything between "self." and "()", including an underscore).
+    # e.g. "self._deploy_storage_classes()" matches "_deploy_storage_classes".
+    #
+    # The parentheses in the regex are a 'capturing group'.
     private_calls = re.findall(r"self\.(\_\w*)\(\)", source)
 
+    # Now we have to dive into the source of the private calls to find any service calls that they use.
+    # Obviously, this is done recursively. As such, there is the possibility that this just loops
+    # infinitely if there is something like a recursive call of a private method in a private method.
+    # But we take those risks!
     for call in private_calls:
         private_method = getattr(cls, call)
         service_calls.extend(_get_method_dependencies(cls, private_method, dependencies_filter))
 
+    # Remove duplicates.
     service_calls = list(set(service_calls))
+
+    # Ensure only dependencies from the dependencies_filter are kept.
     service_calls = list(filter(lambda x: x in dependencies_filter, service_calls))
 
+    # Sort the dependencies for the user's benefit.
     return sorted(service_calls)

--- a/kubails/external_services/dependency_checker.py
+++ b/kubails/external_services/dependency_checker.py
@@ -1,19 +1,42 @@
+import inspect
 import logging
+import re
 import sys
 from functools import reduce, wraps
 from shutil import which
-from typing import Callable
+from typing import Any, Callable, List, Type, TypeVar
 
 
 logger = logging.getLogger(__name__)
 
+# Inspiration for typing 'cls' taken from https://stackoverflow.com/a/56856290.
+T = TypeVar("T")
 
-def check_dependencies(*dependencies) -> Callable:
-    def decorator(func):
+APP_DEPENDENCIES = ("docker", "docker-compose", "gcloud", "git", "helm", "kubectl", "make", "terraform")
+
+
+def check_dependencies(*class_dependencies) -> Callable:
+    if len(class_dependencies) == 0:
+        class_dependencies = APP_DEPENDENCIES
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        for name, method in inspect.getmembers(cls, inspect.isfunction):
+            # Don't decorate private methods.
+            if not name.startswith("_"):
+                method_dependencies = _get_method_dependencies(cls, method, class_dependencies)
+                setattr(cls, name, check_dependencies_for_function(*method_dependencies)(method))
+
+        return cls
+
+    return decorator
+
+
+def check_dependencies_for_function(*dependencies) -> Callable:
+    def decorator(func: Callable) -> Callable:
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args, **kwargs) -> Any:
             _check_dependencies(*dependencies)
-            return func(*args, **kwargs)
+            # return func(*args, **kwargs)
 
         return wrapper
 
@@ -29,8 +52,22 @@ def _check_dependencies(*dependencies) -> None:
 
     if len(missing_deps) > 0:
         missing_deps_string = reduce(lambda acc, dep: acc + "\n- {}".format(dep), missing_deps, "")
-
-        print()
         logger.info("You are missing the following dependencies to run this command: \n{}".format(missing_deps_string))
 
         sys.exit(1)
+
+
+def _get_method_dependencies(cls: Type[T], func: Callable, dependencies_filter) -> List[str]:
+    source = inspect.getsource(func)
+
+    service_calls = re.findall(r"self\.(\w*)\.", source)
+    private_calls = re.findall(r"self\.(\_\w*)\(\)", source)
+
+    for call in private_calls:
+        private_method = getattr(cls, call)
+        service_calls.extend(_get_method_dependencies(cls, private_method, dependencies_filter))
+
+    service_calls = list(set(service_calls))
+    service_calls = list(filter(lambda x: x in dependencies_filter, service_calls))
+
+    return sorted(service_calls)

--- a/kubails/external_services/test_dependency_checker.py
+++ b/kubails/external_services/test_dependency_checker.py
@@ -1,0 +1,46 @@
+from parameterized import parameterized
+from unittest import TestCase
+from . import dependency_checker
+
+
+dependencies_whitelist = ["gcloud",  "terraform"]
+
+
+class MockClass:
+    def __init__(self):
+        self.terraform = {}
+        self.gcloud = {}
+        self.not_a_service = {}
+
+    def mock_method(self):
+        self.gcloud.authenticate_cluster()
+        self.not_a_service.do_a_thing()
+
+    def mock_method_with_private_calls(self):
+        self._mock_private_method()
+        self.gcloud.authenticate_cluster()
+
+    def mock_method_with_nested_private_calls(self):
+        self._mock_private_method_with_private_method()
+
+    def _mock_private_method(self):
+        self.terraform.get_cluster_name()
+
+    def _mock_private_method_with_private_method(self):
+        self._mock_private_method()
+
+
+class TestTerraform(TestCase):
+    @parameterized.expand([
+        # Case 1: Method with just direct service calls.
+        (MockClass, MockClass.mock_method, dependencies_whitelist, ["gcloud"]),
+
+        # Case 2: Method with service calls and private method calls.
+        (MockClass, MockClass.mock_method_with_private_calls, dependencies_whitelist, ["gcloud", "terraform"]),
+
+        # Case 3: Method with nested private method calls.
+        (MockClass, MockClass.mock_method_with_nested_private_calls, dependencies_whitelist, ["terraform"])
+    ])
+    def test_can_get_method_dependencies(self, cls, func, whitelist, expected_result):
+        result = dependency_checker._get_method_dependencies(cls, func, whitelist)
+        self.assertEqual(result, expected_result)

--- a/kubails/external_services/test_terraform.py
+++ b/kubails/external_services/test_terraform.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from . import terraform
 
 
-class TestCli(TestCase):
+class TestTerraform(TestCase):
     def setUp(self):
         self.terraform = terraform.Terraform()
         self.maxDiff = None

--- a/kubails/services/kube_git_syncer.py
+++ b/kubails/services/kube_git_syncer.py
@@ -1,7 +1,7 @@
 import logging
 from functools import reduce
 from typing import List
-from kubails.external_services import git, kubectl
+from kubails.external_services import dependency_checker, git, kubectl
 from kubails.utils.service_helpers import sanitize_name
 
 
@@ -13,6 +13,7 @@ class KubeGitSyncer:
         self.git = git.Git()
         self.kubectl = kubectl.Kubectl()
 
+    @dependency_checker.check_dependencies("git", "kubectl")
     def cleanup_namespaces(self) -> bool:
         # Fetch and prune the branches so that the current repo copy is in
         # sync with the branches on origin

--- a/kubails/services/kube_git_syncer.py
+++ b/kubails/services/kube_git_syncer.py
@@ -8,12 +8,12 @@ from kubails.utils.service_helpers import sanitize_name
 logger = logging.getLogger(__name__)
 
 
+@dependency_checker.check_dependencies()
 class KubeGitSyncer:
     def __init__(self):
         self.git = git.Git()
         self.kubectl = kubectl.Kubectl()
 
-    @dependency_checker.check_dependencies("git", "kubectl")
     def cleanup_namespaces(self) -> bool:
         # Fetch and prune the branches so that the current repo copy is in
         # sync with the branches on origin

--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -30,6 +30,7 @@ DEFAULT_KUBAILS_SERVICE_CONFIG = {
 }
 
 
+@dependency_checker.check_dependencies()
 class Service:
     def __init__(self):
         self.config = config_store.ConfigStore()
@@ -45,7 +46,6 @@ class Service:
             manifests_folder=self.config.get_project_path("manifests")
         )
 
-    @dependency_checker.check_dependencies("docker-compose")
     def start(self, services: List[str]) -> None:
         print()
         logger.info("Starting services locally...")
@@ -53,7 +53,6 @@ class Service:
 
         self.docker_compose.up(services)
 
-    @dependency_checker.check_dependencies("docker-compose")
     def destroy(self) -> None:
         print()
         logger.info("Destroying service containers, networks, and volumes...")
@@ -61,24 +60,19 @@ class Service:
 
         self.docker_compose.down()
 
-    @dependency_checker.check_dependencies("docker", "make")
     def lint(self, services: List[str], tag: str) -> bool:
         return self._run_services_make_command("lint", services, tag)
 
-    @dependency_checker.check_dependencies("docker", "make")
     def test(self, services: List[str], tag: str) -> bool:
         return self._run_services_make_command("test", services, tag)
 
-    @dependency_checker.check_dependencies("docker", "make")
     def ci(self, services: List[str], tag: str) -> bool:
         return self._run_services_make_command("ci", services, tag)
 
-    @dependency_checker.check_dependencies("make")
     def make(self, command: str) -> bool:
         """Run a make command across all of the services."""
         return self._run_services_make_command(command)
 
-    @dependency_checker.check_dependencies("docker")
     def build(self, services: List[str], branch_tag: str = None, commit_tag: str = None) -> bool:
         branch_tag = sanitize_name(branch_tag)
 
@@ -97,7 +91,6 @@ class Service:
 
         return self._apply_to_services(build_function, services)
 
-    @dependency_checker.check_dependencies("docker")
     def push(self, services: List[str], branch_tag: str = None, commit_tag: str = None) -> bool:
         branch_tag = sanitize_name(branch_tag)
 
@@ -125,7 +118,6 @@ class Service:
 
         return self._apply_to_services(push_function, services)
 
-    @dependency_checker.check_dependencies("docker-compose")
     def generate(
         self,
         service_type: str,

--- a/kubails/services/test_config_store.py
+++ b/kubails/services/test_config_store.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from . import config_store
 
 
-class TestCli(TestCase):
+class TestConfigStore(TestCase):
     def setUp(self):
         self.maxDiff = None
 


### PR DESCRIPTION
Changelog:

- Users will now be notified before running a command if they don't have the required dependencies installed to run the command. They are then given the list of dependencies they need to install to run the command.

Implementation Details:

- Went the pretty jank route of using direct source code inspection mixed with some regex and recursion to automatically determine which dependencies each command needs, instead of going the much easier (but totally lazy) route of just checking for all app dependencies before every command.
- Converted some `services/cluster.py` methods to be private after determining they weren't used publicly.
- Fixed the name of some test classes, since they were mistakenly copy-pasted.