### PR TITLE
KBA-49 Fixed the issue of 'infra destroy' still trying to destroy the ingress namespace even when the cluster has already been destroyed.

### DIFF
--- a/kubails/external_services/terraform.py
+++ b/kubails/external_services/terraform.py
@@ -49,7 +49,11 @@ class Terraform:
         return self.run_command("destroy", ["-target", "google_container_cluster.primary"])
 
     def cluster_deployed(self) -> bool:
-        return reduce(lambda acc, state: acc or "module.cluster" in state, self.get_state(), False)
+        return reduce(
+            lambda acc, state: acc or "module.cluster.google_container_cluster" in state,
+            self.get_state(),
+            False
+        )
 
     def get_cluster_name(self) -> str:
         return self.get_output("cluster_name")


### PR DESCRIPTION
Changelog:

- Users who delete their cluster before destroying the rest of their infrastructure will no longer be stuck on waiting for the ingress load balancer to be destroyed when trying to destroy the rest of their infrastructure.

Implementation Details:

- There _was_ a conditional in place for ensuring the cluster actually existed before trying to destroy the ingress load balancer, but it became too broad a condition once we started adding new resources (specifically, the `cluster_database_backup` storage bucket) to the cluster module. Now the condition has been narrowed to work correctly.