### PR TITLE
KBA-33 Fixed generated services potentially having conflicting docker-compose ports.

### DIFF
--- a/kubails/external_services/docker_compose.py
+++ b/kubails/external_services/docker_compose.py
@@ -39,6 +39,7 @@ class DockerCompose:
         if not config["services"]:
             config["services"] = {}
 
+        self._fix_conflicting_ports(config["services"], new_service_config)
         config["services"].update(new_service_config)
 
         self._write_config(config)
@@ -69,3 +70,39 @@ class DockerCompose:
             except yaml.YAMLError as e:
                 logger.exception("Failed to write docker-compose config: " + str(e))
                 raise click.Abort()
+
+    def _fix_conflicting_ports(self, services_config: Dict[str, Any], new_service_config: Dict[str, Any]) -> None:
+        existing_ports = self._get_all_service_ports(services_config)
+
+        for name, config in new_service_config.items():
+            if "ports" in config:
+                fixed_ports = []
+
+                for ports in config["ports"]:
+                    # Remember, ports are specified in the "HOST:CONTAINER" format.
+                    # So the first port in the split is what we have to make sure doesn't conflict.
+                    split_ports = ports.split(":")
+                    host_port = split_ports[0]
+                    container_port = split_ports[1]
+
+                    # Increment the host port until it no longer conflicts.
+                    while host_port in existing_ports:
+                        host_port = str(int(host_port) + 1)
+
+                    # Add the fixed host port to existing ports so that subsequent
+                    # new_service_config ports don't conflict with it.
+                    existing_ports.append(host_port)
+
+                    fixed_ports.append("{}:{}".format(host_port, container_port))
+
+                new_service_config[name]["ports"] = fixed_ports
+
+    def _get_all_service_ports(self, services_config: Dict[str, Any]) -> List[str]:
+        all_ports = []
+
+        for config in services_config.values():
+            if "ports" in config:
+                for ports in config["ports"]:
+                    all_ports.append(ports.split(":")[0])
+
+        return all_ports

--- a/kubails/external_services/docker_compose.py
+++ b/kubails/external_services/docker_compose.py
@@ -20,7 +20,7 @@ yaml.add_representer(type(None), yaml_represent_none)
 
 
 class DockerCompose:
-    def __init__(self, project_name: str, compose_folder: str) -> None:
+    def __init__(self, project_name: str = "", compose_folder: str = "") -> None:
         self.compose_file_location = os.path.join(compose_folder, COMPOSE_FILE)
         self.base_command = ["docker-compose", "-p", project_name, "--file", self.compose_file_location]
 

--- a/kubails/external_services/test_docker_compose.py
+++ b/kubails/external_services/test_docker_compose.py
@@ -1,0 +1,42 @@
+from parameterized import parameterized
+from unittest import TestCase
+from . import docker_compose
+
+
+mock_services_config = {
+    "frontend": {"ports": ["3000:3000"]},
+    "backend": {"ports": ["5000:5000"]}
+}
+
+no_conflicting_ports = {"name": {"ports": ["1000:1000"]}}
+
+one_conflicting_port = {"name": {"ports": ["3000:3000"]}}
+fixed_one_conflicting_port = {"name": {"ports": ["3001:3000"]}}
+
+two_conflicting_port = {"name": {"ports": ["3000:3000", "5000:5000"]}}
+fixed_two_conflicting_port = {"name": {"ports": ["3001:3000", "5001:5000"]}}
+
+consecutive_conflicting_ports = {"name": {"ports": ["3000:3000", "3001:3001"]}}
+fixed_consecutive_conflicting_ports = {"name": {"ports": ["3001:3000", "3002:3001"]}}
+
+
+class TestDockerCompose(TestCase):
+    def setUp(self):
+        self.docker_compose = docker_compose.DockerCompose()
+
+    @parameterized.expand([
+        # Case 1: No conflicting ports.
+        (mock_services_config, no_conflicting_ports, no_conflicting_ports),
+
+        # Case 2: One conflicting port in the new service.
+        (mock_services_config, one_conflicting_port, fixed_one_conflicting_port),
+
+        # Case 3: Two conflicting port in the new service.
+        (mock_services_config, two_conflicting_port, fixed_two_conflicting_port),
+
+        # Case 4: Consecutive conflicting ports.
+        (mock_services_config, consecutive_conflicting_ports, fixed_consecutive_conflicting_ports)
+    ])
+    def test_can_fix_conflicting_ports(self, services_config, new_service_config, fixed_service_config):
+        self.docker_compose._fix_conflicting_ports(services_config, new_service_config)
+        self.assertEqual(new_service_config, fixed_service_config)

--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -130,7 +130,7 @@ class Service:
         subdomain = subdomain.lower().replace(" ", "-")
         config_generator = SERVICES_CONFIG[service_type](name, self.config, extra_config)
 
-        print("")  # Just a new line for user output
+        print()  # Just a new line for user output
 
         self._template_service(service_type, title, name)
         self._add_service_to_kubails_config(config_generator, name, subdomain)


### PR DESCRIPTION
Changelog:

- Users can now use `kubails service generate` without having to worry about the new generated service having a conflicting `docker-compose` port with an existing service. 

Implementation Details:

- The new service will have their host ports incremented until they no longer conflict with existing services.