### PR TITLE
KBA-42 Added the ability to deploy a Slack build failure notifier.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include kubails/builder *
 recursive-include kubails/templates *
+recursive-include kubails/resources *

--- a/kubails/commands/notify.py
+++ b/kubails/commands/notify.py
@@ -34,3 +34,11 @@ def slack():
 @log_command_args
 def success(webhook: str, namespace: str, commit: str) -> None:
     notify_service.send_slack_success_message(webhook, namespace=namespace, commit=commit)
+
+
+@slack.command()
+@click.argument("webhook")
+@click.option("--repo")
+@log_command_args
+def deploy_failure_notifier(webhook: str, repo: str) -> None:
+    notify_service.deploy_slack_failure_notifier(webhook, repo_name=repo)

--- a/kubails/resources/build_notifier/.gcloudignore
+++ b/kubails/resources/build_notifier/.gcloudignore
@@ -1,0 +1,19 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+node_modules
+scripts
+Makefile
+README.md

--- a/kubails/resources/build_notifier/.gitignore
+++ b/kubails/resources/build_notifier/.gitignore
@@ -1,0 +1,105 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+*.pyc
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+node_modules/
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Visual Studio Code
+.vscode

--- a/kubails/resources/build_notifier/BaseNotifier.js
+++ b/kubails/resources/build_notifier/BaseNotifier.js
@@ -1,0 +1,14 @@
+class BaseNotifier {
+    constructor({id, status, logUrl, sha, provider, owner, repo, branch}) {
+        this.id = id;
+        this.status = status;
+        this.logUrl = logUrl;
+        this.sha = sha;
+        this.provider = provider;
+        this.owner = owner;
+        this.repo = repo;
+        this.branch = branch;
+    }
+}
+
+module.exports = BaseNotifier;

--- a/kubails/resources/build_notifier/BitbucketNotifier.js
+++ b/kubails/resources/build_notifier/BitbucketNotifier.js
@@ -1,0 +1,56 @@
+const axios = require("axios");
+const BaseNotifier = require("./BaseNotifier");
+
+const BITBUCKET_TOKEN_KEY_NAME = "BITBUCKET_ACCESS_TOKEN";
+const BITBUCKET_USER_KEY_NAME = "BITBUCKET_USER";
+
+// Map of Cloud Build statuses to Bitbucket statuses.
+const BITBUCKET_STATUS_MAP = {
+    QUEUED: "INPROGRESS",
+    WORKING: "INPROGRESS",
+    SUCCESS: "SUCCESSFUL",
+    FAILURE: "FAILED",
+    INTERNAL_ERROR: "FAILED",
+    TIMEOUT: "FAILED",
+    CANCELLED: "STOPPED"
+};
+
+class BitbucketNotifier extends BaseNotifier {
+    async updateStatus() {
+        // Get the access token and user.
+        const accessToken = process.env.BITBUCKET_ACCESS_TOKEN;
+        const user = process.env.BITBUCKET_USER;
+
+        if (!accessToken || !user) {
+            console.log("Bitbucket access token:");
+            console.log(accessToken);
+            console.log("Bitbucket user:");
+            console.log(user);
+
+            throw new Error("Bitbucket access token or user not specified.");
+        }
+
+        try {
+            const url = this.generateUrl(this.owner, this.repo, this.sha, accessToken, user);
+
+            // Post the new status to the commit SHA at Bitbucket.
+            return axios.post(url, {
+                state: BITBUCKET_STATUS_MAP[this.status],
+                description: `Cloud Build status: ${this.status}`,
+                url: this.logUrl,
+                key: "GCP-CLOUD-BUILD"
+            });
+        } catch (e) {
+            console.log("Bitbucket request error: ");
+            console.log(e);
+
+            throw new Error(e);
+        }
+    }
+
+    generateUrl(owner, repo, sha, accessToken, user) {
+        return `https://${user}:${accessToken}@api.bitbucket.org/2.0/repositories/${owner}/${repo}/commit/${sha}/statuses/build`;
+    }
+}
+
+module.exports = BitbucketNotifier;

--- a/kubails/resources/build_notifier/GithubNotifier.js
+++ b/kubails/resources/build_notifier/GithubNotifier.js
@@ -1,0 +1,61 @@
+const axios = require("axios");
+const BaseNotifier = require("./BaseNotifier");
+
+const GITHUB_KEY_NAME = "GITHUB_ACCESS_TOKEN";
+
+// Map of Cloud Build statuses to Github statuses.
+const GITHUB_STATUS_MAP = {
+    QUEUED: "pending",
+    WORKING: "pending",
+    SUCCESS: "success",
+    FAILURE: "failure",
+    INTERNAL_ERROR: "error",
+    TIMEOUT: "error",
+    CANCELLED: "failure"
+};
+
+class GithubNotifier extends BaseNotifier {
+    async updateStatus() {
+        // Get the access token.
+        const accessToken = process.env.GITHUB_ACCESS_TOKEN;
+
+        if (!accessToken) {
+            console.log("GitHub access token:");
+            console.log(accessToken);
+
+            throw new Error("GitHub access token not specified.");
+        }
+
+        try {
+            const url = this.generateUrl(this.owner, this.repo, this.sha, accessToken);
+
+            // Post the new status to the commit SHA at Github
+            return axios.post(
+                url,
+                {
+                    state: GITHUB_STATUS_MAP[this.status],
+                    description: `Cloud Build status: ${this.status}`,
+                    target_url: this.logUrl,
+                    context: "GCP Cloud Build"
+                },
+                {
+                    headers: {
+                        "User-Agent": "Cloud Build Notifier",
+                        "Authorization": `token ${accessToken}`,
+                    }
+                }
+            );
+        } catch (e) {
+            console.log("GitHub request error:")
+            console.log(e);
+
+            throw new Error(e);
+        }
+    }
+
+    generateUrl(owner, repo, sha, accessToken) {
+        return `https://api.github.com/repos/${owner}/${repo}/statuses/${sha}`;
+    }
+}
+
+module.exports = GithubNotifier;

--- a/kubails/resources/build_notifier/SlackNotifier.js
+++ b/kubails/resources/build_notifier/SlackNotifier.js
@@ -1,0 +1,50 @@
+const {IncomingWebhook} = require("@slack/webhook");
+const BaseNotifier = require("./BaseNotifier");
+
+class SlackNotifier extends BaseNotifier {
+    async sendMessage() {
+        // Get the URL for the webhook.
+        const webhookUrl = process.env.SLACK_WEBHOOK;
+
+        if (!webhookUrl) {
+            console.log("Slack webhook url:");
+            console.log(webhookUrl);
+
+            throw new Error("Slack webhook url not specified.");
+        }
+
+        const webhook = new IncomingWebhook(webhookUrl);
+
+        const message = {
+            mrkdwn: true,
+            attachments: [
+                {
+                    title: `Build \`${this.id}\``,
+                    title_link: this.logUrl,
+                    color: "danger",
+                    fields: [{
+                        title: "Status",
+                        value: this.status,
+                        short: true
+                    }, {
+                        title: "Repo",
+                        value: this.repo,
+                        short: true
+                    }, {
+                        title: "Branch",
+                        value: this.branch,
+                        short: true
+                    }, {
+                        title: "Commit",
+                        value: this.sha.slice(0, 7),
+                        short: true
+                    }]
+                }
+            ]
+        };
+
+        return webhook.send(message);
+    }
+}
+
+module.exports = SlackNotifier;

--- a/kubails/resources/build_notifier/index.js
+++ b/kubails/resources/build_notifier/index.js
@@ -1,0 +1,219 @@
+const BaseNotifier = require("./BaseNotifier");
+const BitbucketNotifier = require("./BitbucketNotifier");
+const GithubNotifier = require("./GithubNotifier");
+const SlackNotifier = require("./SlackNotifier");
+
+const PROVIDER_BITBUCKET = "bitbucket";
+const PROVIDER_GITHUB = "github";
+const SUPPORTED_PROVIDERS = [PROVIDER_BITBUCKET, PROVIDER_GITHUB];
+
+const PROVIDER_NOTIFIER_MAP = {
+    [PROVIDER_BITBUCKET]: BitbucketNotifier,
+    [PROVIDER_GITHUB]: GithubNotifier
+};
+
+// (theoretically) All of the Cloud Build statuses.
+const ACTIONABLE_STATUSES = [
+    "QUEUED", "WORKING", "SUCCESS", "FAILURE",
+    "INTERNAL_ERROR", "TIMEOUT", "CANCELLED"
+];
+
+const FAILURE_STATUSES = [
+    "FAILURE", "INTERNAL_ERROR", "TIMEOUT"
+];
+
+/* A Cloud Function that gets called whenever a message is pushed to the 'cloud-builds' topic.
+ * Handles Bitbucket/Github notifications.
+ */
+exports.gitHostNotifier = async (data, context) => {
+    const notifierData = extractNotifierData(data, context, ACTIONABLE_STATUSES);
+
+    if (!notifierData) {
+        return;
+    }
+
+    const Notifier = PROVIDER_NOTIFIER_MAP[notifierData.provider];
+    const notifier = new Notifier(notifierData);
+
+    return notifier.updateStatus();
+};
+
+/* A Cloud Function that gets called whenever a message is pushed to the 'cloud-builds' topic.
+ * Handles Slack failure notifications.
+ */
+exports.slackFailureNotifier = async (data, context) => {
+    const notifierData = extractNotifierData(data, context, FAILURE_STATUSES);
+
+    if (!notifierData) {
+        return;
+    }
+
+    const slackNotifier = new SlackNotifier(notifierData);
+    return slackNotifier.sendMessage();
+};
+
+const extractNotifierData = (data, context, statuses = ACTIONABLE_STATUSES) => {
+    const build = parseBuild(data.data);
+
+    // See the end of this file for a sample 'build' object.
+    const {id, status, logUrl} = build;
+
+    if (!build.sourceProvenance) {
+        // This build doesn't come from a repo; no need to notify anything.
+        // For example, App Engine can create builds for itself when deploying.
+        return null;
+    }
+
+    const sha = build.sourceProvenance.resolvedRepoSource.commitSha;
+
+    if (!sha) {
+        // This build doesn't come from a repo; no need to notify anything.
+        // For example, App Engine can create builds for itself when deploying.
+        return null;
+    }
+
+    const {provider, owner, repo} = parseRepoInfo(build);
+    const branch = build.source.repoSource.branchName;
+
+    if (
+        // Ignore statuses that we don't care about for this notifier.
+        // e.g. We use all statuses (ACTIONABLE_STATUSES) for Github/Bitbucket,
+        // but we only use the failure statuses (FAILURE_STATUSES) for Slack.
+        (statuses.indexOf(status) === -1)
+
+        // Make sure the provider is supported.
+        || (!SUPPORTED_PROVIDERS.includes(provider))
+
+        // Only send messages to the specified repo, if one was specified.
+        || (process.env.TARGET_REPO && repo !== process.env.TARGET_REPO && process.env.TARGET_REPO !== "all")
+    ) {
+        return null;
+    }
+
+    return new BaseNotifier({id, status, logUrl, sha, provider, owner, repo, branch});
+};
+
+const parseBuild = (data) => JSON.parse(new Buffer(data, "base64").toString());
+
+const parseRepoInfo = (build) => {
+    // `build.source.repoSource.repoName` looks like this: 'github_devinsit_kubails'.
+    //
+    // This function assumes a general format of PROVIDER_OWNER_REPO-NAME.
+    // This is very likely to not always be true.
+    // For example, it used to be hyphens instead of underscores!
+
+    const repoInfo = build.source.repoSource.repoName;
+    const [provider, owner, ...repo] = repoInfo.split("_");
+
+    return {
+        provider,
+        owner,
+        // Recombine the repo name if it used underscores.
+        repo: repo.join("_")
+    };
+};
+
+/*
+
+(LATEST) Build object structure for reference (Bitbucket).
+
+"{ id: 'ecec9d77-b929-4707-972c-c4fe2a40bc4c',
+  projectId: 'devinsit-personal-projects',
+  status: 'WORKING',
+  source:
+   { repoSource:
+      { projectId: 'devinsit-personal-projects',
+        repoName: 'bitbucket_dsrobo620_kubails',     <--- Note how it uses underscores instead of hypens now
+        branchName: 'KBA-19' } },
+  steps:
+   [ { name: 'kennethreitz/pipenv',
+       args: [Array],
+       id: 'Install dependencies, test, and lint',
+       waitFor: [Array],
+       entrypoint: 'bash' } ],
+  createTime: '2018-12-14T04:17:23.162340120Z',
+  startTime: '2018-12-14T04:17:24.112070151Z',
+  timeout: '600s',
+  logsBucket: 'gs://26871575867.cloudbuild-logs.googleusercontent.com',
+  sourceProvenance:
+   { resolvedRepoSource:
+      { projectId: 'devinsit-personal-projects',
+        repoName: 'bitbucket_dsrobo620_kubails',
+        commitSha: 'ad1ad09c81b6865a6135b38421b7fbe828a77eaa' } },
+  buildTriggerId: 'daab55ff-3431-4508-bb0d-b21aa0ca7926',
+  options: { substitutionOption: 'ALLOW_LOOSE', logging: 'LEGACY' },
+  logUrl: 'https://console.cloud.google.com/gcr/builds/ecec9d77-b929-4707-972c-c4fe2a40bc4c?project=26871575867',
+  tags:
+   [ 'event-a308a8f6-610b-4b7d-b2fb-19a15a1ce924',
+     'trigger-daab55ff-3431-4508-bb0d-b21aa0ca7926' ] } 'build'"
+ */
+
+/*
+(OLD) Build object structure for reference (Github).
+
+{ id: '09858dba-2518-48c1-ad88-b7fe497cab64',
+ projectId: 'testing-kubails',
+ status: 'WORKING',
+ source:
+  { repoSource:
+	 { projectId: 'testing-kubails',
+	   repoName: 'github-devinsit-kubails',
+	   branchName: 'APU-20' } },
+ steps:
+  [ { name: 'kennethreitz/pipenv',
+	  args: [Object],
+	  entrypoint: 'bash' } ],
+ createTime: '2018-04-26T00:22:07.585674768Z',
+ startTime: '2018-04-26T00:22:08.514193270Z',
+ timeout: '600s',
+ logsBucket: 'gs://93509042731.cloudbuild-logs.googleusercontent.com',
+ sourceProvenance:
+  { resolvedRepoSource:
+	 { projectId: 'testing-kubails',
+	   repoName: 'github-devinsit-kubails',
+	   commitSha: '8e9dd680f8c26ea41cc73866a1227bf0ec40e774' } },
+ buildTriggerId: 'a500fb04-91a4-4d34-ab5d-f2de2d5928e5',
+ options: { substitutionOption: 'ALLOW_LOOSE' },
+ logUrl: 'https://console.cloud.google.com/gcr/builds/09858dba-2518-48c1-ad88-b7fe497cab64?project=93509042731
+',
+ substitutions:
+  { _INVOCATION_ID: '5bfbf49e-4c09-4bc6-9f6e-82f13584bf66',
+	_PLAN_EVALUATION_ID: '9bb2c42c-5615-4c63-863b-4cd45ad115f6',
+	_PROJECT_NUMBER: '93509042731' },
+ tags:
+  [ 'event-885991ab-a45b-4691-af6a-6a7a64f3f07e',
+	'trigger-a500fb04-91a4-4d34-ab5d-f2de2d5928e5',
+	'eval-9bb2c42c-5615-4c63-863b-4cd45ad115f6',
+	'invocation-5bfbf49e-4c09-4bc6-9f6e-82f13584bf66' ] }
+*/
+
+/*
+(OLD) Build object structure for reference (Bitbucket).
+
+{ id: '4e675e8e-2403-46ab-a5a5-91ed761a4f3a',
+ projectId: 'buzzword-bingo-app',
+ status: 'WORKING',
+ source:
+  { repoSource:
+	 { projectId: 'buzzword-bingo-app',
+	   repoName: 'bitbucket-dsrobo620-cookie-test',
+	   branchName: 'testing-3' } },
+ steps:
+  [ { name: 'gcr.io/buzzword-bingo-app/builder',
+	  args: [Object] } ],
+ createTime: '2018-08-27T01:16:41.113768989Z',
+ startTime: '2018-08-27T01:16:41.864562994Z',
+ timeout: '600s',
+ logsBucket: 'gs://550665981060.cloudbuild-logs.googleusercontent.com',
+ sourceProvenance:
+  { resolvedRepoSource:
+	 { projectId: 'buzzword-bingo-app',
+	   repoName: 'bitbucket-dsrobo620-cookie-test',
+	   commitSha: '2b6fcdf42a880693b8d7b60b0a6394478b6e2a78' } },
+ buildTriggerId: '1aec2694-c44d-4d8c-bd31-9e97fc3bf342',
+ options: { substitutionOption: 'ALLOW_LOOSE' },
+ logUrl: 'https://console.cloud.google.com/gcr/builds/4e675e8e-2403-46ab-a5a5-91ed761a4f3a?project=550665981060',
+ tags:
+  [ 'event-2525932f-f44e-4d37-b421-da671c248abd',
+	'trigger-1aec2694-c44d-4d8c-bd31-9e97fc3bf342' ] }
+*/

--- a/kubails/resources/build_notifier/package-lock.json
+++ b/kubails/resources/build_notifier/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "name": "cloud-build-notifier",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@slack/types": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.5.0.tgz",
+      "integrity": "sha512-oCYgatJYxHf9wE3tKXzOLeeTsF0ghX1TIcguNfVmO2V6NDe+cHAzZRglEOmJLdRINDS5gscAgSkeZpDhpKBeUA=="
+    },
+    "@slack/webhook": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-5.0.3.tgz",
+      "integrity": "sha512-51vnejJ2zABNumPVukOLyerpHQT39/Lt0TYFtOEz/N2X77bPofOgfPj2atB3etaM07mxWHLT9IRJ4Zuqx38DkQ==",
+      "requires": {
+        "@slack/types": "^1.2.1",
+        "@types/node": ">=8.9.0",
+        "axios": "^0.19.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "requires": {
+            "follow-redirects": "1.5.10"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        }
+      }
+    },
+    "@types/node": {
+      "version": "10.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
+      "integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ=="
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    }
+  }
+}

--- a/kubails/resources/build_notifier/package.json
+++ b/kubails/resources/build_notifier/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "cloud-build-notifier",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@slack/webhook": "^5.0.3",
+    "axios": "^0.19.2"
+  }
+}

--- a/kubails/services/config_store.py
+++ b/kubails/services/config_store.py
@@ -156,6 +156,7 @@ class ConfigStore:
         self.apis_to_enable = [
             "cloudkms.googleapis.com",
             "cloudbuild.googleapis.com",
+            "cloudfunctions.googleapis.com",
             "cloudresourcemanager.googleapis.com",
             "compute.googleapis.com",
             "container.googleapis.com",

--- a/kubails/services/notify.py
+++ b/kubails/services/notify.py
@@ -1,17 +1,57 @@
 import click
 import logging
-from kubails.external_services import slack
+import os
+from kubails.external_services import gcloud, slack
 from kubails.services import config_store
-from kubails.utils.service_helpers import sanitize_name
+from kubails.utils.service_helpers import get_codebase_subfolder, sanitize_name
 
 
 logger = logging.getLogger(__name__)
+
+NOTIFIER_FOLDER = "build_notifier"
+
+# This is the PubSub topic that the notifier is triggered on.
+NOTIFIER_TRIGGER = "cloud-builds"
+
+# This value is taken from 'resources/build_notifier/index.js'.
+# It is the exported function for the slack failure notifier.
+SLACK_FAILURE_NOTIFIER_ENTRYPOINT = "slackFailureNotifier"
 
 
 class Notify:
     def __init__(self):
         self.config = config_store.ConfigStore()
+
+        self.gcloud = gcloud.GoogleCloud(
+            self.config.gcp_project_id,
+            self.config.gcp_project_region,
+            self.config.gcp_project_zone
+        )
+
         self.slack = slack.Slack()
+
+    def deploy_slack_failure_notifier(self, slack_webhook: str, repo_name: str = None) -> None:
+        if not repo_name:
+            # Yes, the repo is assumed to just be the project_name.
+            # This is also true for the Terraform configs.
+            # TODO: This should probably be changed at some point.
+            repo_name = self.config.project_name
+
+        notifier_name = "{}-slack-failure-notifier".format(self.config.project_name)
+        notifier_source = os.path.join(get_codebase_subfolder("resources"), NOTIFIER_FOLDER)
+
+        env_vars = {
+            "SLACK_WEBHOOK": slack_webhook,
+            "TARGET_REPO": repo_name
+        }
+
+        self.gcloud.deploy_function(
+            notifier_name,
+            notifier_source,
+            entrypoint=SLACK_FAILURE_NOTIFIER_ENTRYPOINT,
+            trigger=NOTIFIER_TRIGGER,
+            env_vars=env_vars
+        )
 
     def send_slack_success_message(
         self,


### PR DESCRIPTION
Changelog:

- Users now have access to the `kubails notify slack deploy-failure-notifier` command. This will deploy a small Cloud Function that watches for failed builds for your repo and pushes failure messages to the Slack channel of your choice.

Implementation Details:

- Brought in my custom Cloud Function for handling Slack/GitHub/Bitbucket notifications (the command for deploying the GitHub/Bitbucket notifier will come in a later ticket).
- The Cloud Functions API is now enabled as part of `kubails infra setup`.
- Added a new `resources` folder that will hold this kind of non-python code stuff. Will have to move the Builder into it in the future.