### PR TITLE
KBA-40 Added the ability to deploy GitHub and Bitbucket build status notifiers.

### DIFF
--- a/kubails/commands/notify.py
+++ b/kubails/commands/notify.py
@@ -42,3 +42,30 @@ def success(webhook: str, namespace: str, commit: str) -> None:
 @log_command_args
 def deploy_failure_notifier(webhook: str, repo: str) -> None:
     notify_service.deploy_slack_failure_notifier(webhook, repo_name=repo)
+
+
+############################################################
+# Git sub-group
+############################################################
+
+
+@notify.group()
+def git():
+    pass
+
+
+@git.command()
+@click.argument("access_token")
+@click.option("--repo")
+@log_command_args
+def deploy_github_notifier(access_token: str, repo: str) -> None:
+    notify_service.deploy_github_notifier(access_token, repo_name=repo)
+
+
+@git.command()
+@click.argument("access_token")
+@click.argument("user")
+@click.option("--repo")
+@log_command_args
+def deploy_bitbucket_notifier(access_token: str, user: str, repo: str) -> None:
+    notify_service.deploy_bitbucket_notifier(access_token, user, repo_name=repo)

--- a/kubails/services/notify.py
+++ b/kubails/services/notify.py
@@ -1,6 +1,7 @@
 import click
 import logging
 import os
+from typing import Dict
 from kubails.external_services import gcloud, slack
 from kubails.services import config_store
 from kubails.utils.service_helpers import get_codebase_subfolder, sanitize_name
@@ -13,9 +14,10 @@ NOTIFIER_FOLDER = "build_notifier"
 # This is the PubSub topic that the notifier is triggered on.
 NOTIFIER_TRIGGER = "cloud-builds"
 
-# This value is taken from 'resources/build_notifier/index.js'.
-# It is the exported function for the slack failure notifier.
+# Theses values are taken from 'resources/build_notifier/index.js'.
 SLACK_FAILURE_NOTIFIER_ENTRYPOINT = "slackFailureNotifier"
+GITHUB_NOTIFIER_ENTRYPOINT = "githubNotifier"
+BITBUCKET_NOTIFIER_ENTRYPOINT = "bitbucketNotifier"
 
 
 class Notify:
@@ -31,26 +33,30 @@ class Notify:
         self.slack = slack.Slack()
 
     def deploy_slack_failure_notifier(self, slack_webhook: str, repo_name: str = None) -> None:
-        if not repo_name:
-            # Yes, the repo is assumed to just be the project_name.
-            # This is also true for the Terraform configs.
-            # TODO: This should probably be changed at some point.
-            repo_name = self.config.project_name
+        self._deploy_notifier(
+            notifier_name="slack-failure-notifier",
+            notifier_entrypoint=SLACK_FAILURE_NOTIFIER_ENTRYPOINT,
+            env_vars={"SLACK_WEBHOOK": slack_webhook},
+            repo_name=repo_name
+        )
 
-        notifier_name = "{}-slack-failure-notifier".format(self.config.project_name)
-        notifier_source = os.path.join(get_codebase_subfolder("resources"), NOTIFIER_FOLDER)
+    def deploy_github_notifier(self, access_token: str, repo_name: str = None) -> None:
+        self._deploy_notifier(
+            notifier_name="github-notifier",
+            notifier_entrypoint=GITHUB_NOTIFIER_ENTRYPOINT,
+            env_vars={"GITHUB_ACCESS_TOKEN": access_token},
+            repo_name=repo_name
+        )
 
-        env_vars = {
-            "SLACK_WEBHOOK": slack_webhook,
-            "TARGET_REPO": repo_name
-        }
-
-        self.gcloud.deploy_function(
-            notifier_name,
-            notifier_source,
-            entrypoint=SLACK_FAILURE_NOTIFIER_ENTRYPOINT,
-            trigger=NOTIFIER_TRIGGER,
-            env_vars=env_vars
+    def deploy_bitbucket_notifier(self, access_token: str, user: str, repo_name: str = None) -> None:
+        self._deploy_notifier(
+            notifier_name="bitbucket-notifier",
+            notifier_entrypoint=BITBUCKET_NOTIFIER_ENTRYPOINT,
+            env_vars={
+                "BITBUCKET_ACCESS_TOKEN": access_token,
+                "BITBUCKET_USER": user,
+            },
+            repo_name=repo_name
         )
 
     def send_slack_success_message(
@@ -90,4 +96,27 @@ class Notify:
             title="Cluster Deployment Completed",
             fields=fields,
             color="good"
+        )
+
+    def _deploy_notifier(
+        self,
+        notifier_name: str = "",
+        notifier_entrypoint: str = "",
+        env_vars: Dict[str, str] = {},
+        repo_name: str = None
+    ) -> None:
+        if not repo_name:
+            # Yes, the repo is assumed to just be the project_name.
+            # This is also true for the Terraform configs.
+            # TODO: This should probably be changed at some point.
+            repo_name = self.config.project_name
+
+        notifier_source = os.path.join(get_codebase_subfolder("resources"), NOTIFIER_FOLDER)
+
+        self.gcloud.deploy_function(
+            "{}-{}".format(repo_name, notifier_name),
+            notifier_source,
+            entrypoint=notifier_entrypoint,
+            trigger=NOTIFIER_TRIGGER,
+            env_vars={**env_vars, "TARGET_REPO": repo_name}
         )

--- a/kubails/templates/primary/{{cookiecutter.project_name}}/cloudbuild.yaml
+++ b/kubails/templates/primary/{{cookiecutter.project_name}}/cloudbuild.yaml
@@ -58,9 +58,9 @@ steps:
       name: "gcr.io/$PROJECT_ID/kubails-builder"
       args: ["kubails", "infra", "unauthenticate"]
 
-    - id: "Send slack success notification"
-      name: "gcr.io/$PROJECT_ID/kubails-builder"
-      args: ["kubails", "notify", "slack", "success", "${_SLACK_WEBHOOK}", "--namespace", "${BRANCH_NAME}", "--commit", "${SHORT_SHA}"]
+    # - id: "Send slack success notification"
+    #   name: "gcr.io/$PROJECT_ID/kubails-builder"
+    #   args: ["kubails", "notify", "slack", "success", "${_SLACK_WEBHOOK}", "--namespace", "${BRANCH_NAME}", "--commit", "${SHORT_SHA}"]
 
 substitutions:
     _SLACK_WEBHOOK: ""


### PR DESCRIPTION
Changelog:

- Users now have access to the `kubails notify git deploy-github-notifier/deploy-bitbucket-notifier` commands. This will deploy a small Cloud Function that forwards Cloud Build statuses to your hosted git repo of choice.
- Users will find that the Slack success notification step of the Cloud Build pipeline has been disabled by default on new projects. This is to enable new users to have a working build pipeline from the get-go without having to integrate Slack. To enable the step, just uncomment the lines in `cloudbuild.yaml`.

Implementation Details:

- Refactored the build notifier to have separate exports for GitHub and Bitbucket. This is to support the distinct commands detailed above.