### PR TITLE
KBA-71 Fixed the wildcard certificate updating code for 'service generate' to not fail when there exists services without a 'host' field.

### DIFF
--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -265,9 +265,9 @@ class Service:
         domains = [self.config.domain, "*.{}".format(self.config.domain)]
 
         for service, config in config["__services"].items():
-            host = config["host"]
+            host = config.get("host", None)
 
-            if "ingress" in config["templates"] and host not in domains:
+            if "ingress" in config["templates"] and host is not None and host not in domains:
                 domains.append("*.{}".format(host))
 
         certificate_manifest_location = "cert-manager/wildcard-certificate.yaml"


### PR DESCRIPTION
Changelog:

- Users will no longer find that `kubails service generate` crashes when there exists services without the 'host' field (e.g. for databases).

Implementation Details:

- N/A