### PR TITLE
KBA-72 Modified the 'cleanup-namespaces' to output the cleaned up namespaces for extensibility purposes. 

### DIFF
--- a/kubails/services/config_store.py
+++ b/kubails/services/config_store.py
@@ -166,6 +166,7 @@ class ConfigStore:
             "replicapool.googleapis.com",
             "replicapoolupdater.googleapis.com",
             "resourceviews.googleapis.com",
+            "secretmanager.googleapis.com",
             "sourcerepo.googleapis.com"
         ]
 

--- a/kubails/services/config_store.py
+++ b/kubails/services/config_store.py
@@ -174,6 +174,7 @@ class ConfigStore:
         self.service_account_token_creator_role = "roles/iam.serviceAccountTokenCreator"
         self.service_account_key_admin_role = "roles/iam.serviceAccountKeyAdmin"
         self.crypto_key_decrypter_role = "roles/cloudkms.cryptoKeyDecrypter"
+        self.secret_manager_role = "roles/secretmanager.admin"
 
         self.values_folder = "helm/values"
 

--- a/kubails/services/infra.py
+++ b/kubails/services/infra.py
@@ -54,6 +54,10 @@ class Infra:
             "serviceAccount", cloud_build_service_account, self.config.crypto_key_decrypter_role
         )
 
+        self.gcloud.add_role_to_entity(
+            "serviceAccount", cloud_build_service_account, self.config.secret_manager_role
+        )
+
         # Create the Terraform state bucket (if it doesn't already exist) and initialize Terraform to use it.
         terraform_bucket = self.config.terraform_state_bucket
 

--- a/kubails/services/kube_git_syncer.py
+++ b/kubails/services/kube_git_syncer.py
@@ -25,8 +25,20 @@ class KubeGitSyncer:
 
         unused_namespaces = _get_unused_namespaces(remote_branches, existing_namespaces)
 
+        def cleanup_namespace(namespace: str) -> bool:
+            result = self.kubectl.delete_namespace(namespace)
+
+            if result:
+                # Print the namespace so that it acts as output for the command.
+                # This way, the cleanup command can be extended to do other things in user-land.
+                # Note: Don't use the logger here, since we need the namespace to go to stdout
+                # so that it can be captured in a variable.
+                print(namespace)
+
+            return result
+
         return reduce(
-            lambda acc, namespace: acc and self.kubectl.delete_namespace(namespace),
+            lambda acc, namespace: acc and cleanup_namespace(namespace),
             unused_namespaces,
             True
         )


### PR DESCRIPTION
Changelog:

- The `kubails cluster cleanup-namespaces` now outputs the namespaces that were cleaned up so that other scripts can operate on them.
- Added the Secret Manager API to the list of APIs to enable.
- Added the Secret Manager Admin role to the Cloud Build service account.
- Fixed the `resources`  folder to have an `__init__.py` file so that it is a module and doesn't cause a bunch of errors when using `kubails` as an installed CLI (vs dev-mode).