### PR TITLE
KBA-75 Added new 'kubails service has-changed' and 'kubails cluster is-new-namespace' commands.

### DIFF
--- a/kubails/commands/cluster.py
+++ b/kubails/commands/cluster.py
@@ -51,6 +51,15 @@ def cleanup_namespaces() -> None:
     kube_git_syncer_service.cleanup_namespaces()
 
 
+@cluster.command()
+@click.argument("namespace")
+@log_command_args
+def is_new_namespace(namespace: str) -> None:
+    """Returns whether or not the given namespace is new."""
+    if not cluster_service.is_new_namespace(namespace):
+        sys.exit(1)
+
+
 ############################################################
 # Manifests sub-group
 ############################################################

--- a/kubails/commands/service.py
+++ b/kubails/commands/service.py
@@ -3,6 +3,7 @@ import logging
 import sys
 from typing import Tuple
 from kubails.commands import helpers
+from kubails.services.config_store import ConfigStore
 from kubails.services.service import Service
 from kubails.resources.templates import SERVICE_TEMPLATES
 from kubails.utils.command_helpers import log_command_args_factory
@@ -11,14 +12,17 @@ from kubails.utils.command_helpers import log_command_args_factory
 logger = logging.getLogger(__name__)
 log_command_args = log_command_args_factory(logger, "Service '{}' args")
 
+config_store = None
 service_service = None
 
 
 @click.group()
 def service():
     """Manage the services for your project."""
+    global config_store
     global service_service
 
+    config_store = ConfigStore()
     service_service = Service()
 
 
@@ -120,6 +124,15 @@ def generate(service_type: str, subdomain: str, title: str) -> None:
         subdomain=subdomain,
         title=title,
     )
+
+
+@service.command()
+@click.argument("service")
+@log_command_args
+def has_changed(service: str) -> None:
+    """Returns whether or not the given service has changed since the last build."""
+    if not config_store.is_changed_service(service):
+        sys.exit(1)
 
 
 ############################################################

--- a/kubails/main.py
+++ b/kubails/main.py
@@ -37,7 +37,7 @@ def construct_cli(commands: Sequence[Union[click.Command, click.Group]], docstri
                 # Ideally `kubails infra authenticate` is the first command of the pipeline.
                 cluster.authenticate()
 
-                if cluster.is_new_namespace_cloud_build(branch):
+                if cluster.is_new_namespace(branch):
                     logger.info("Using all services: '{}' is a new branch".format(branch))
                     return
 

--- a/kubails/services/cluster.py
+++ b/kubails/services/cluster.py
@@ -195,17 +195,14 @@ class Cluster:
         logger.info("Created {} and updated kubails.json with secrets info.".format(encrypted_file))
 
     def is_new_namespace(self, namespace: str) -> bool:
-        namespace = sanitize_name(namespace)
-        namespaces = self.kubectl.get_namespaces()
-
-        return namespace not in namespaces
-
-    # Need to use Cloud Build caching because there might be steps in Cloud Build that happen after the
-    # namespace ends up being created but that still rely on knowing whether or not the namespace is new.
-    def is_new_namespace_cloud_build(self, namespace: str) -> bool:
         def callback() -> str:
-            return "True" if self.is_new_namespace(namespace) else "False"
+            sanitized_namespace = sanitize_name(namespace)
+            namespaces = self.kubectl.get_namespaces()
 
+            return "True" if sanitized_namespace not in namespaces else "False"
+
+        # Need to use Cloud Build caching because there might be steps in Cloud Build that happen after the
+        # namespace ends up being created but that still rely on knowing whether or not the namespace is new.
         return self.gcloud.cache_in_cloud_build("is_new_namespace.txt", callback) == "True"
 
     def _deploy_storage_classes(self) -> None:


### PR DESCRIPTION
Changelog:

- Users can now use the `kubails service has-changed` and `kubails cluster is-new-namespace` commands to check those state values (e.g. in a build pipeline).

Implementation Details:

- N/A

Tech Debt:

- N/A