### PR TITLE
KBA-74 Upgraded Terraform in the Builder to the latest v0.14.9.

### DIFF
--- a/kubails/external_services/terraform.py
+++ b/kubails/external_services/terraform.py
@@ -77,7 +77,7 @@ class Terraform:
         return self._run_terraform_command(get_state_command, call_function=get_command_output).split("\n")
 
     def get_output(self, output: str) -> str:
-        command = self.base_command + ["output", output]
+        command = self.base_command + ["output", "-json", output]
         result = self._run_terraform_command(command, get_command_output)
 
         if not result:

--- a/kubails/external_services/terraform.py
+++ b/kubails/external_services/terraform.py
@@ -88,7 +88,7 @@ class Terraform:
 
             raise click.Abort()
 
-        return result
+        return result.strip('"')
 
     def run_command(self, subcommand: str, arguments: List[str] = [], with_vars=True) -> bool:
         command = self.base_command + [subcommand] + arguments

--- a/kubails/resources/builder/Dockerfile
+++ b/kubails/resources/builder/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:16.04
 
 ENV KUBECTL_VERSION="v1.11.2"
 ENV HELM_VERSION="v2.10.0"
-ENV TERRAFORM_VERSION="0.12.30"
+ENV TERRAFORM_VERSION="0.14.9"
 ENV PATH="/builder/google-cloud-sdk/bin:${PATH}"
 
 # These env variables are needed to prevent Click from complaining

--- a/kubails/resources/builder/Dockerfile
+++ b/kubails/resources/builder/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:16.04
 
 ENV KUBECTL_VERSION="v1.11.2"
 ENV HELM_VERSION="v2.10.0"
-ENV TERRAFORM_VERSION="0.11.14"
+ENV TERRAFORM_VERSION="0.12.30"
 ENV PATH="/builder/google-cloud-sdk/bin:${PATH}"
 
 # These env variables are needed to prevent Click from complaining


### PR DESCRIPTION
Changelog:

- Users will find that the Terraform version in the Builder has now been upgraded to the latest version (v0.14.9).
- Users will have to manually upgrade their own Terraform configs to conform to the changes since the last version (v0.11).

Implementation Details:

- Had to modify the Terraform service to add `-json` to all `terraform output` commands, since the output format changed.
- Had to add quote stripping to all `terraform output` commands, since the `-json` output was adding quotes.

Tech Debt:

- Have yet to upgrade Kubails' default Terraform configs to conform to the syntax changes made from Terraform v0.11 -> v0.14. This will be done (sometime, in the future) as part of KBA-76.