### PR TITLE
KBA-77 Enabled support for caching multi-stage Docker image builds.

### DIFF
--- a/kubails/external_services/docker.py
+++ b/kubails/external_services/docker.py
@@ -10,24 +10,42 @@ class Docker:
     def __init__(self):
         self.base_command = ["docker"]
 
-    def build(self, context: str, tags: List[str] = [], cache_image: str = None, branch: str = None) -> bool:
-        command = self.base_command + ["build"]
-
-        for tag in tags:
-            command.extend(["-t", tag])
-
-        if cache_image:
-            command.extend(["--cache-from", cache_image])
+    def build(
+        self,
+        context: str,
+        tags: List[str] = [],
+        target_stage: str = None,
+        cache_images: List[str] = [],
+        branch: str = None,
+    ) -> bool:
+        command = self.base_command + [
+            "build",
+            # Need this in CI so that every log is output as its own line.
+            "--progress=plain",
+            # Need this otherwise the built images can't be used as cache images.
+            # IDK why, I guess it's just a BuildKit thing.
+            "--build-arg=BUILDKIT_INLINE_CACHE=1",
+        ]
 
         if branch:
             command.extend(["--build-arg", "branch={}".format(branch)])
 
+        if target_stage:
+            command.extend(["--target", target_stage])
+
+        for cache_image in cache_images:
+            if self.pull(cache_image):
+                command.extend(["--cache-from", cache_image])
+            else:
+                logger.info("No cache found for image {}.".format(cache_image))
+
+        for tag in tags:
+            command.extend(["-t", tag])
+
         command.append(context)
 
-        if cache_image and not self.pull(cache_image):
-            logger.info("No cache found for image {}.".format(cache_image))
-
-        return call_command(command)
+        # Enable BuildKit to get 'faster' builds (supposedly).
+        return call_command(command, env={"DOCKER_BUILDKIT": "1"})
 
     def pull(self, image: str) -> bool:
         command = self.base_command + ["pull", image]

--- a/kubails/resources/builder/Dockerfile
+++ b/kubails/resources/builder/Dockerfile
@@ -1,7 +1,7 @@
 # This image fills the gap of needing ruby, docker, and helm in a single Cloud Builder step 
 # (since we have ruby scripts that call out to these other tools).
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV KUBECTL_VERSION="v1.11.2"
 ENV HELM_VERSION="v2.10.0"
@@ -29,8 +29,7 @@ RUN apt-get -y update \
         unzip \
     # Setup docker PPA
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
-    && apt-key fingerprint 0EBFCD88 \
-    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial edge" \ 
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" \
     # Setup git PPA
     && add-apt-repository ppa:git-core/ppa \
     # Install build tools

--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -98,9 +98,10 @@ class Service:
                     result = result and self.docker.build(service_path, [tagged_images["latest"]])
                 else:  # CI/CD pipeline use case
                     cache_image = tagged_images["fixed_tag"] if fixed_tag else tagged_images["branch"]
+                    master_cache_image = tagged_images["master"]
 
                     # Each previous stage image is used to build the next stage.
-                    cache_images = stage_images + [cache_image]
+                    cache_images = stage_images + [cache_image, master_cache_image]
                     stage_images.append(cache_image)
 
                     # If we're on the last image, then that means it's the final stage and
@@ -241,6 +242,7 @@ class Service:
         images["base"] = self.gcloud.format_gcr_image(self.config.project_name, base_image)
 
         images["latest"] = "{}:latest".format(images["base"])
+        images["master"] = "{}:master".format(images["base"])
         images["branch"] = "{}:{}".format(images["base"], branch_tag)
         images["commit"] = "{}:{}".format(images["base"], commit_tag)
         images["fixed_tag"] = "{}:{}".format(images["base"], fixed_tag)

--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -85,21 +85,39 @@ class Service:
         def build_function(service: str) -> bool:
             service_path = self._get_service_path(service)
             fixed_tag = self._get_fixed_tag(service)
-            base_image = self._get_base_image_name(service)
+            base_images = self._get_base_images(service)
 
-            images = self._generate_tagged_images(base_image, branch_tag, commit_tag, fixed_tag=fixed_tag)
+            stage_images = []  # type: List[str]
+            result = True
 
-            if not branch_tag and not commit_tag:  # Local dev use case
-                return self.docker.build(service_path, [images["latest"]])
-            else:  # CI/CD pipeline use case
-                cache_image = images["fixed_tag"] if fixed_tag else images["branch"]
+            for index, base_image in enumerate(base_images):
+                is_last_image = index == len(base_images) - 1
+                tagged_images = self._generate_tagged_images(base_image, branch_tag, commit_tag, fixed_tag=fixed_tag)
 
-                return self.docker.build(
-                    service_path,
-                    list(images.values()),
-                    cache_image=cache_image,
-                    branch=branch_tag
-                )
+                if not branch_tag and not commit_tag:  # Local dev use case
+                    result = result and self.docker.build(service_path, [tagged_images["latest"]])
+                else:  # CI/CD pipeline use case
+                    cache_image = tagged_images["fixed_tag"] if fixed_tag else tagged_images["branch"]
+
+                    # Each previous stage image is used to build the next stage.
+                    cache_images = stage_images + [cache_image]
+                    stage_images.append(cache_image)
+
+                    # If we're on the last image, then that means it's the final stage and
+                    # # we don't need to specify a target stage.
+                    # Otherwise, each previous stage needs to specify a target in the Dockerfile to be
+                    # built (and pushed) separately.
+                    target_stage = None if is_last_image else base_image
+
+                    result = result and self.docker.build(
+                        service_path,
+                        list(tagged_images.values()),
+                        target_stage=target_stage,
+                        cache_images=cache_images,
+                        branch=branch_tag
+                    )
+
+            return result
 
         return self._apply_to_services(build_function, services)
 
@@ -108,25 +126,27 @@ class Service:
 
         def push_function(service: str) -> bool:
             fixed_tag = self._get_fixed_tag(service)
-            base_image = self._get_base_image_name(service)
+            base_images = self._get_base_images(service)
 
-            images = self._generate_tagged_images(base_image, branch_tag, commit_tag, fixed_tag=fixed_tag)
+            result = True
 
-            if not branch_tag and not commit_tag:  # Local dev use case
-                return self.docker.push(images["latest"])
-            else:  # CI/CD pipeline use case
-                result = True
+            for base_image in base_images:
+                tagged_images = self._generate_tagged_images(base_image, branch_tag, commit_tag, fixed_tag=fixed_tag)
 
-                if fixed_tag:
-                    result = result and self.docker.push(images["fixed_tag"])
-                else:
-                    result = result and self.docker.push(images["branch"])
-                    result = result and self.docker.push(images["commit"])
+                if not branch_tag and not commit_tag:  # Local dev use case
+                    result = result and self.docker.push(tagged_images["latest"])
+                else:  # CI/CD pipeline use case
 
-                    if branch_tag == self.config.production_namespace:
-                        result = result and self.docker.push(images["latest"])
+                    if fixed_tag:
+                        result = result and self.docker.push(tagged_images["fixed_tag"])
+                    else:
+                        result = result and self.docker.push(tagged_images["branch"])
+                        result = result and self.docker.push(tagged_images["commit"])
 
-                return result
+                        if branch_tag == self.config.production_namespace:
+                            result = result and self.docker.push(tagged_images["latest"])
+
+            return result
 
         return self._apply_to_services(push_function, services)
 
@@ -155,7 +175,7 @@ class Service:
         tag = sanitize_name(tag)
 
         def function(service: str) -> bool:
-            base_image = self._get_base_image_name(service)
+            base_image = self._get_base_images(service)[-1]
 
             cache_image = self.gcloud.format_gcr_image(self.config.project_name, base_image, tag)
             cache_option = "" if not tag else "--cache-from={}".format(cache_image)
@@ -190,8 +210,21 @@ class Service:
         folder = self.config.get_service_folder(service)
         return self.config.get_project_path(os.path.join(SERVICES_FOLDER, folder))
 
-    def _get_base_image_name(self, service: str) -> str:
-        return self.config.services.get(service, {}).get("image", service)
+    def _get_base_images(self, service: str) -> List[str]:
+        base_image = self.config.services.get(service, {}).get("image", service)
+        image_stages = self.config.services.get(service, {}).get("image_stages", [])
+
+        # If `image_stages` is provided in the config, then that means that the service uses a multi-stage Dockerfile.
+        # As such, we want to build the specified stages before the final image, so that we can push them separately,
+        # so that we can cache them separately, so that we actually cache improvements for subsequent builds.
+        #
+        # If we don't cache each stage image separately, then we get no caching for the final image, since it
+        # will be completely separate from the previous stages.
+        #
+        # Note: The values listed in `image_stages` must correspond to the names of the stages in the Dockerfile
+        # If a stage is declared as `FROM node:14 as build-env`, then `image_stages` must contain `build-env`.
+        # This is because the images are tagged the same as the stages.
+        return image_stages + [base_image]
 
     def _get_fixed_tag(self, service: str) -> str:
         return self.config.services.get(service, {}).get("fixed_tag", None)

--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -98,10 +98,10 @@ class Service:
                     result = result and self.docker.build(service_path, [tagged_images["latest"]])
                 else:  # CI/CD pipeline use case
                     cache_image = tagged_images["fixed_tag"] if fixed_tag else tagged_images["branch"]
-                    master_cache_image = tagged_images["master"]
+                    prod_cache_image = tagged_images[self.config.production_namespace]
 
                     # Each previous stage image is used to build the next stage.
-                    cache_images = stage_images + [cache_image, master_cache_image]
+                    cache_images = stage_images + [cache_image, prod_cache_image]
                     stage_images.append(cache_image)
 
                     # If we're on the last image, then that means it's the final stage and
@@ -238,11 +238,12 @@ class Service:
         fixed_tag: str = None
     ) -> Dict[str, str]:
         images = {}
+        prod_branch = self.config.production_namespace
 
         images["base"] = self.gcloud.format_gcr_image(self.config.project_name, base_image)
 
         images["latest"] = "{}:latest".format(images["base"])
-        images["master"] = "{}:master".format(images["base"])
+        images[prod_branch] = "{}:{}".format(images["base"], prod_branch)
         images["branch"] = "{}:{}".format(images["base"], branch_tag)
         images["commit"] = "{}:{}".format(images["base"], commit_tag)
         images["fixed_tag"] = "{}:{}".format(images["base"], fixed_tag)


### PR DESCRIPTION
Changelog:

- Users can now add the `image_stages` property a service in `kubails.json`. This property lists all of the stages used in the Dockerfile of a service, not including the last one. This is used to speed up builds by caching each stage individually.
- Production namespace (e.g. 'master') images are now used as cache images when building other branches.

Implementation Details:

- Modified the `kubails service build/push` commands to support multi-stage builds by always using a loop to process the images.
- Upgraded the Builder to Ubuntu 18.04 to get the latest Docker CLI.
- Enabled 'BuildKit' when building images using Docker, cause... faster.
- Modified the Docker `build` method to support building singular stages in a multi-stage buildo

Tech Debt:

- BuildKit still isn't the default in Docker, so we'll need to revisit this in the future once it is.
- The decision to just add another `kubails.json` propery (wimage_stages`) to support multi-stage builds is kinda janky... but it works.