### PR TITLE
KBA-78 Fixed BuildKit + mirrors issue; fixed multi-stage image caching issue.

### DIFF
--- a/kubails/external_services/docker.py
+++ b/kubails/external_services/docker.py
@@ -35,11 +35,11 @@ class Docker:
             command.extend(["--target", target_stage])
 
         for cache_image in cache_images:
-            command.extend(["--cache-from", cache_image])
-            # if self.pull(cache_image):
-            #   command.extend(["--cache-from", cache_image])
-            # else:
-            #     logger.info("No cache found for image {}.".format(cache_image))
+            if self.pull(cache_image):
+                logger.info("Using {} as a cache image.".format(cache_image))
+                command.extend(["--cache-from", cache_image])
+            else:
+                logger.info("No cache found for image {}.".format(cache_image))
 
         for tag in tags:
             command.extend(["-t", tag])

--- a/kubails/external_services/docker.py
+++ b/kubails/external_services/docker.py
@@ -35,10 +35,11 @@ class Docker:
             command.extend(["--target", target_stage])
 
         for cache_image in cache_images:
-            if self.pull(cache_image):
-                command.extend(["--cache-from", cache_image])
-            else:
-                logger.info("No cache found for image {}.".format(cache_image))
+            command.extend(["--cache-from", cache_image])
+            # if self.pull(cache_image):
+            #   command.extend(["--cache-from", cache_image])
+            # else:
+            #     logger.info("No cache found for image {}.".format(cache_image))
 
         for tag in tags:
             command.extend(["-t", tag])

--- a/kubails/external_services/docker.py
+++ b/kubails/external_services/docker.py
@@ -35,11 +35,9 @@ class Docker:
             command.extend(["--target", target_stage])
 
         for cache_image in cache_images:
-            if self.pull(cache_image):
-                logger.info("Using {} as a cache image.".format(cache_image))
-                command.extend(["--cache-from", cache_image])
-            else:
-                logger.info("No cache found for image {}.".format(cache_image))
+            self.pull(cache_image)
+            logger.info("Using {} as a cache image.".format(cache_image))
+            command.extend(["--cache-from", cache_image])
 
         for tag in tags:
             command.extend(["-t", tag])

--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -100,14 +100,8 @@ class Service:
                     cache_image = tagged_images["fixed_tag"] if fixed_tag else tagged_images["branch"]
 
                     # Each previous stage image is used to build the next stage.
-                    cache_images = stage_images + [cache_image]
+                    cache_images = stage_images + [cache_image, tagged_images["latest"]]
                     stage_images.append(cache_image)
-
-                    # Use the production namespace image as a cache image for other branches.
-                    # This should greatly speed up new branch builds, since it had to do a full build
-                    # everytime before.
-                    if branch_tag != self.config.production_namespace:
-                        cache_images.append(tagged_images[self.config.production_namespace])
 
                     # If we're on the last image, then that means it's the final stage and
                     # we don't need to specify a target stage.
@@ -248,12 +242,9 @@ class Service:
         images["latest"] = "{}:latest".format(images["base"])
         images["branch"] = "{}:{}".format(images["base"], branch_tag)
         images["commit"] = "{}:{}".format(images["base"], commit_tag)
-        images["fixed_tag"] = "{}:{}".format(images["base"], fixed_tag)
 
-        # Include a tag for the production namespace, so that the production image can be used as a cache
-        # image on new branches, greatly speeding up initial build for new branches.
-        prod_branch = self.config.production_namespace
-        images[prod_branch] = "{}:{}".format(images["base"], prod_branch)
+        if fixed_tag:
+            images["fixed_tag"] = "{}:{}".format(images["base"], fixed_tag)
 
         return images
 

--- a/kubails/services/service.py
+++ b/kubails/services/service.py
@@ -101,7 +101,7 @@ class Service:
 
                     # Each previous stage image is used to build the next stage.
                     cache_images = stage_images + [cache_image, tagged_images["latest"]]
-                    stage_images.append(cache_image)
+                    stage_images.append(tagged_images["commit"])
 
                     # If we're on the last image, then that means it's the final stage and
                     # we don't need to specify a target stage.


### PR DESCRIPTION
Changelog:

- When running `kubails service images build`, all 'FROM' images are now explicitly pulled, to work around an issue with Docker BuildKit and registy mirrors (https://github.com/moby/buildkit/issues/1972).
- Fixed the multi-stage building of `kubails service images build` so that the commit tag of the previous stages is used for subsequent stages (rather than the branch tag). This way, the branch tagged image doesn't get overriden by the subsequent stage pulling the image as part of the cache image logic.

Implementation Details:

- Changed the 'fixed_tag' tag to only be added if the 'fixed_tag' exists, so that we don't end up with images tagged as "None".

Tech Debt:

- The workaround for the BuildKit + mirrors issue is, indeed, tech debt.