### PR TITLE
KBA-79 Fixed the 'changed services' algorithm to work better.

### DIFF
--- a/kubails/commands/service.py
+++ b/kubails/commands/service.py
@@ -128,10 +128,11 @@ def generate(service_type: str, subdomain: str, title: str) -> None:
 
 @service.command()
 @click.argument("service")
+@click.option("--current-branch", default="master")
 @log_command_args
-def has_changed(service: str) -> None:
+def has_changed(current_branch: str, service: str) -> None:
     """Returns whether or not the given service has changed since the last build."""
-    if not config_store.is_changed_service(service):
+    if not config_store.is_changed_service(service, current_branch):
         sys.exit(1)
 
 

--- a/kubails/external_services/git.py
+++ b/kubails/external_services/git.py
@@ -40,3 +40,13 @@ class Git:
         # If the command is successful, then that means there _no_ changes.
         # But since we want to know if the folder _did_ change, we have to invert the result.
         return not call_command(command)
+
+    def get_commit_timestamp(self, commit_sha: str) -> int:
+        # Note: "--format=%ct" gets the timestamp as a Unix epoch timestamp.
+        # Makes it easier for sorting.
+        command = self.base_command + ["show", "--quiet", "-s", "--format=%ct", commit_sha]
+
+        output = get_command_output(command)
+
+        # If the commit_sha isn't a valid commit, then the output will be blank. Return 0 instead.
+        return int(output) if output else 0

--- a/kubails/external_services/git.py
+++ b/kubails/external_services/git.py
@@ -30,12 +30,12 @@ class Git:
 
         return sorted(filtered_branches)
 
-    def folder_changed(self, folder: str, since_commit: str) -> bool:
+    def folder_changed(self, folder: str, current_branch: str, since_commit: str) -> bool:
         # Need the full git history to diff commits.
         self.fetch("origin", prune=True)
         self.fetch("origin", prune=True, unshallow=True)
 
-        command = self.base_command + ["diff", "--quiet", "HEAD", since_commit, "--", folder]
+        command = self.base_command + ["diff", "--quiet", current_branch, since_commit, "--", folder]
 
         # If the command is successful, then that means there _no_ changes.
         # But since we want to know if the folder _did_ change, we have to invert the result.

--- a/kubails/external_services/git.py
+++ b/kubails/external_services/git.py
@@ -35,6 +35,9 @@ class Git:
         self.fetch("origin", prune=True)
         self.fetch("origin", prune=True, unshallow=True)
 
+        # Need to checkout the current_branch, otherwise it doesn't exist for the diff command.
+        call_command(self.base_command + ["checkout", current_branch])
+
         command = self.base_command + ["diff", "--quiet", current_branch, since_commit, "--", folder]
 
         # If the command is successful, then that means there _no_ changes.

--- a/kubails/main.py
+++ b/kubails/main.py
@@ -15,13 +15,13 @@ logger = create_logger()  # noqa: Create the root logger for submodules to use
 def construct_cli(commands: Sequence[Union[click.Command, click.Group]], docstring: str) -> click.Group:
     @click.group(context_settings=CONTEXT_SETTINGS, help=docstring)
     @click.version_option(version=VERSION)
-    @click.option("--only-changed-services", is_flag=True)
+    @click.option("--only-changed-services")
     @click.option(
         "--all-services-branch",
         help="Pass the branch to override --only-changed-services for new branches and production."
     )
-    def cli(only_changed_services: bool, all_services_branch: str):
-        if (only_changed_services):
+    def cli(only_changed_services: str, all_services_branch: str):
+        if only_changed_services:
             config = config_store.ConfigStore()
             cluster = cluster_service.Cluster()
 
@@ -41,7 +41,7 @@ def construct_cli(commands: Sequence[Union[click.Command, click.Group]], docstri
                     logger.info("Using all services: '{}' is a new branch".format(branch))
                     return
 
-            config.use_changed_services()
+            config.use_changed_services(only_changed_services)
 
     for command in commands:
         cli.add_command(command)

--- a/kubails/services/cluster.py
+++ b/kubails/services/cluster.py
@@ -89,7 +89,9 @@ class Cluster:
         result = result and self._cleanup_manifests()
         logger.info("Generating new manifests...")
 
-        services_dict = {s: self.config.services[s] for s in services} if services else self.config.services
+        services_dict = {
+            s: self.config.services[s] for s in services if s in self.config.services
+        } if services else self.config.services
 
         for service, config in services_dict.items():
             output_dir = os.path.join(self.manifest_manager.generated_manifest_location(""), service)
@@ -124,7 +126,9 @@ class Cluster:
         result = True
         namespace = sanitize_name(namespace)
 
-        services_dict = {s: self.config.services[s] for s in services} if services else self.config.services
+        services_dict = {
+            s: self.config.services[s] for s in services if s in self.config.services
+        } if services else self.config.services
 
         if namespace:
             self.kubectl.create_namespace(namespace, label="kube-git-syncer=\"true\"")
@@ -140,7 +144,7 @@ class Cluster:
         namespace = sanitize_name(namespace)
 
         services_dict = {
-            s: self.config.services_with_secrets[s] for s in services
+            s: self.config.services_with_secrets[s] for s in services if s in self.config.services
         } if services else self.config.services_with_secrets
 
         for service, config in services_dict.items():

--- a/kubails/services/config_store.py
+++ b/kubails/services/config_store.py
@@ -275,15 +275,22 @@ class _ConfigStore(object):
                 fixed_tag = services[service].get("fixed_tag", None)
                 tag = self.gcloud.get_last_built_tag_for_service(self.project_name, service)
 
+                test1 = (fixed_tag and tag == fixed_tag)
+                test2 = self.git.folder_changed(os.path.join(SERVICES_FOLDER, folder), current_branch, tag)
+
+                print(service)
+                print(tag)
+                print(test2)
+
                 if folder and tag:
                     if (
                         # If the service has a fixed tag, then we'll never actually know if it has changed
                         # or not, because we don't have old commit tags to cache bust on.
                         #
                         # As such, just always include them.
-                        (fixed_tag and tag == fixed_tag) or
+                        test1 or
                         # Otherwise, use our magic function for determining whether the service changed.
-                        self.git.folder_changed(os.path.join(SERVICES_FOLDER, folder), current_branch, tag)
+                        test2
                     ):
                         services_with_changes.append(service)
 

--- a/kubails/services/config_store.py
+++ b/kubails/services/config_store.py
@@ -121,23 +121,23 @@ class _ConfigStore(object):
     def get_service_folder(self, service: str) -> str:
         return self.services.get(service, {}).get("folder", service)
 
-    def get_changed_services(self) -> List[str]:
+    def get_changed_services(self, current_branch: str) -> List[str]:
         def callback() -> str:
             # Need to convert the list to a string for caching.
-            return ",".join(self._get_service_names_with_changes())
+            return ",".join(self._get_service_names_with_changes(current_branch))
 
         # Leverage Cloud Build caching so that the changed services don't need to be re-computed every step.
         return self.gcloud.cache_in_cloud_build("changed_services.txt", callback).split(",")
 
-    def use_changed_services(self) -> None:
-        service_names = self.get_changed_services()
+    def use_changed_services(self, current_branch: str) -> None:
+        service_names = self.get_changed_services(current_branch)
         logger.info("Using only changed services: {}".format(service_names))
 
         self.services = filter_dict(self.services, service_names)  # type: Dict[str, Dict[str, Any]]
         self.services_with_code = filter_dict(self.services_with_code, service_names)  # type: Dict[str, Dict[str, Any]]
 
-    def is_changed_service(self, service: str) -> bool:
-        return service in self.get_changed_services()
+    def is_changed_service(self, service: str, current_branch: str) -> bool:
+        return service in self.get_changed_services(current_branch)
 
     def _search_for_file_dir(self, file_name: str) -> str:
         current_dir = os.getcwd()
@@ -264,7 +264,7 @@ class _ConfigStore(object):
         else:
             return None
 
-    def _get_service_names_with_changes(self) -> List[str]:
+    def _get_service_names_with_changes(self, current_branch: str) -> List[str]:
         services = self.services
         services_with_changes = []
 
@@ -283,7 +283,7 @@ class _ConfigStore(object):
                         # As such, just always include them.
                         (fixed_tag and tag == fixed_tag) or
                         # Otherwise, use our magic function for determining whether the service changed.
-                        self.git.folder_changed(os.path.join(SERVICES_FOLDER, folder), tag)
+                        self.git.folder_changed(os.path.join(SERVICES_FOLDER, folder), current_branch, tag)
                     ):
                         services_with_changes.append(service)
 

--- a/kubails/services/config_store.py
+++ b/kubails/services/config_store.py
@@ -275,22 +275,15 @@ class _ConfigStore(object):
                 fixed_tag = services[service].get("fixed_tag", None)
                 tag = self.gcloud.get_last_built_tag_for_service(self.project_name, service)
 
-                test1 = (fixed_tag and tag == fixed_tag)
-                test2 = self.git.folder_changed(os.path.join(SERVICES_FOLDER, folder), current_branch, tag)
-
-                print(service)
-                print(tag)
-                print(test2)
-
                 if folder and tag:
                     if (
                         # If the service has a fixed tag, then we'll never actually know if it has changed
                         # or not, because we don't have old commit tags to cache bust on.
                         #
                         # As such, just always include them.
-                        test1 or
+                        (fixed_tag and tag == fixed_tag) or
                         # Otherwise, use our magic function for determining whether the service changed.
-                        test2
+                        self.git.folder_changed(os.path.join(SERVICES_FOLDER, folder), current_branch, tag)
                     ):
                         services_with_changes.append(service)
 


### PR DESCRIPTION
Changelog:

- The `--only-changed-services` now 'requires' that the branch name is passed.
- The `service has-changed` command now has a 'required' `--current-branch` option for the same reasons as the above.
- Fixed the `cluster manifests generate/deploy` commands to work when passing in a hard-coded list of services while using `--only-changed-services`.
- Improved/fixed the 'changed services' algorithm to... work.

Implementation Details:

- The 'changed services' algorithm previously always used `HEAD` for determining diffs. This was obviously wrong, so now it has been changed to check against the current branch. Hence, the need for the `--only-changed-services` option to have the branch passed.
- The above is also true for the `service has-changed --current-branch` command.
- The 'changed services' algorithm previously assumed that the first tag on the latest image of a service was the latest (i.e. last uploaded) tag. This assumption has been proven to not hold, so the algorithm now checks all tags to find the one with the latest git timestamp.

Tech Debt:

- The result of not thoroughly testing the 'changed services' algorithm in KBA-73 has now caught up with us. What other aspects of it are totally broken?...